### PR TITLE
New *exec command, to run 'batch files' of MOS commands (like autoexec.txt)

### DIFF
--- a/main.c
+++ b/main.c
@@ -57,7 +57,6 @@ extern volatile	char 	keycode;		// Keycode
 extern volatile char	gp;				// General poll variable
 
 static FATFS 	fs;						// Handle for the file system
-static char  	cmd[256];				// Array for the command line handler
 
 // Wait for the ESP32 to respond with a GP packet to signify it is ready
 // Parameters:

--- a/main.c
+++ b/main.c
@@ -137,7 +137,10 @@ int main(void) {
 	//
 	#if enable_config == 1	
 	if(coldBoot > 0) {								// Check it's a cold boot (after reset, not RST 00h)
-		mos_BOOT("autoexec.txt", cmd, sizeof cmd);	// Then load and run the config file
+		int err = mos_EXEC("autoexec.txt", cmd, sizeof cmd);	// Then load and run the config file
+		if (err > 0) {
+			mos_error(err);
+		}
 	}	
 	#endif
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -50,6 +50,8 @@
 #include "clock.h"
 #include "ff.h"
 
+char  	cmd[256];				// Array for the command line handler
+
 extern void *	set_vector(unsigned int vector, void(*handler)(void));	// In vectors16.asm
 
 extern int 		exec16(UINT24 addr, char * params);	// In misc.asm
@@ -84,6 +86,7 @@ static t_mosCommand mosCommands[] = {
 	{ "VDU",		&mos_cmdVDU		},
 	{ "TIME", 		&mos_cmdTIME	},
 	{ "CREDITS",	&mos_cmdCREDITS	},
+	{ "EXEC",		&mos_cmdEXEC	},
 };
 
 #define mosCommands_count (sizeof(mosCommands)/sizeof(t_mosCommand))
@@ -413,6 +416,27 @@ int mos_cmdLOAD(char * ptr) {
 	if(!mos_parseNumber(NULL, &addr)) addr = MOS_defaultLoadAddress;
 	fr = mos_LOAD(filename, addr, 0);
 	return fr;	
+}
+
+// EXEC <filename>
+//   Run a batch file containing MOS commands
+// Parameters:
+// - ptr: Pointer to the argument string in the line edit buffer
+// Returns:
+// - MOS error code
+//
+int mos_cmdEXEC(char *ptr) {
+	FRESULT	fr;
+	char *  filename;
+	UINT24 	addr;
+	
+	if(
+		!mos_parseString(NULL, &filename)
+	) {
+		return 19; // Bad Parameter
+	}
+	fr = mos_EXEC(filename, cmd, sizeof cmd);
+	return fr;
 }
 
 // SAVE <filename> <addr> <len> command
@@ -886,6 +910,36 @@ UINT24 mos_BOOT(char * filename, char * buffer, UINT24 size) {
 		while(!f_eof(&fil)) {
 			f_gets(buffer, size, &fil);
 			mos_exec(buffer);
+		}
+	}
+	f_close(&fil);	
+	return fr;	
+}
+
+// Load and run a batch file of MOS commands.
+// It is similar to mos_BOOT, but stops if a command returns an error
+// Parameters:
+// - filename: The config file to execute
+// - buffer: Storage for each line to be loaded into and executed from (recommend 256 bytes)
+// - size: Size of buffer (in bytes)
+// Returns:
+// - FatFS return code (of the last command)
+//
+UINT24 mos_EXEC(char * filename, char * buffer, UINT24 size) {
+	FRESULT	fr;
+	FIL	   	fil;
+	UINT   	br;	
+	void * 	dest;
+	FSIZE_t fSize;
+	
+	fr = f_open(&fil, filename, FA_READ);
+	if(fr == FR_OK) {
+		while(!f_eof(&fil)) {
+			f_gets(buffer, size, &fil);
+			fr = mos_exec(buffer);
+			if (fr != FR_OK) {
+				break;
+			}
 		}
 	}
 	f_close(&fil);	

--- a/src/mos.h
+++ b/src/mos.h
@@ -35,6 +35,8 @@
 
 #include "ff.h"
 
+extern char  	cmd[256];				// Array for the command line handler
+
 typedef struct {
 	char * name;
 	int (*func)(char * ptr);
@@ -75,6 +77,7 @@ int		mos_cmdSET(char *ptr);
 int		mos_cmdVDU(char *ptr);
 int		mos_cmdTIME(char *ptr);
 int		mos_cmdCREDITS(char *ptr);
+int		mos_cmdEXEC(char * ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
@@ -85,6 +88,7 @@ UINT24 	mos_REN(char * filename1, char * filename2);
 UINT24	mos_COPY(char * filename1, char * filename2);
 UINT24	mos_MKDIR(char * filename);
 UINT24 	mos_BOOT(char * filename, char * buffer, UINT24 size);
+UINT24 	mos_EXEC(char * filename, char * buffer, UINT24 size);
 
 UINT24	mos_FOPEN(char * filename, UINT8 mode);
 UINT24	mos_FCLOSE(UINT8 fh);

--- a/src/mos.h
+++ b/src/mos.h
@@ -87,7 +87,6 @@ UINT24	mos_DEL(char * filename);
 UINT24 	mos_REN(char * filename1, char * filename2);
 UINT24	mos_COPY(char * filename1, char * filename2);
 UINT24	mos_MKDIR(char * filename);
-UINT24 	mos_BOOT(char * filename, char * buffer, UINT24 size);
 UINT24 	mos_EXEC(char * filename, char * buffer, UINT24 size);
 
 UINT24	mos_FOPEN(char * filename, UINT8 mode);


### PR DESCRIPTION
This differs from the old autoexec.txt process in that it stops on the first error encountered, and does report the error.

Autoexec.txt execution is refactored to use the same code as *exec. This also closes a reported issue, that autoexec.txt execution silently swallows errors.