### PR TITLE
Semantic versioning

### DIFF
--- a/main.c
+++ b/main.c
@@ -35,6 +35,7 @@
 #include <String.h>
 
 #include "defines.h"
+#include "version.h"
 #include "config.h"
 #include "uart.h"
 #include "spi.h"
@@ -42,10 +43,6 @@
 #include "ff.h"
 #include "clock.h"
 #include "mos.h"
-
-#define		MOS_version		1
-#define		MOS_revision 	4
-#define		MOS_rc			2
 
 extern void *	set_vector(unsigned int vector, void(*handler)(void));
 
@@ -118,9 +115,13 @@ int main(void) {
 	if(coldBoot == 0) {								// If a warm boot detected then
 		putch(12);									// Clear the screen
 	}
-	printf("Agon Quark MOS Version %d.%02d", MOS_version, MOS_revision);
-	#if MOS_rc > 0
-		printf(" RC%d", MOS_rc);
+	printf("Agon %s MOS Version %d.%d.%d", VERSION_VARIANT, VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
+	#if VERSION_CANDIDATE > 0
+		printf(" %s%d", VERSION_TYPE, VERSION_CANDIDATE);
+	#endif
+	// Show build if defined (intended to be auto-generated string from build script from git commit hash)
+	#ifdef VERSION_BUILD
+		printf(" Build %s", VERSION_BUILD);
 	#endif
 	printf("\n\r\n\r");
 	#if	DEBUG > 0

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,12 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define		VERSION_MAJOR		2
+#define		VERSION_MINOR		0
+#define		VERSION_PATCH		0
+#define		VERSION_CANDIDATE	1			// Optional
+#define		VERSION_TYPE		"Alpha "	// RC, Alpha, Beta, etc.
+
+#define		VERSION_VARIANT		"Console8"
+
+#endif // VERSION_H


### PR DESCRIPTION
move version info out to `version.h` file

version info now a semantic version, with major, minor, patch, and “candidate” info, as well as an indicator for candidate type (displayed if candidate number is non-zero)

support for showing an automatically-generated build number added, which can be provided by a build script and is intended to be derived from the git hash

with this approach it should also be possible in the future to add other tooling to automatically increment version numbers

version info also includes the codebase variant, allowing us to easily differentiate between Quark and Console8