### PR TITLE
hide error when there is no autoexec.txt file

### DIFF
--- a/main.c
+++ b/main.c
@@ -136,7 +136,7 @@ int main(void) {
 	#if enable_config == 1	
 	if(coldBoot > 0) {								// Check it's a cold boot (after reset, not RST 00h)
 		int err = mos_EXEC("autoexec.txt", cmd, sizeof cmd);	// Then load and run the config file
-		if (err > 0) {
+		if (err > 0 && err != FR_NO_FILE) {
 			mos_error(err);
 		}
 	}	

--- a/src/mos.h
+++ b/src/mos.h
@@ -194,9 +194,9 @@ UINT8	fat_EOF(FIL * fp);
 
 #define HELP_HELP	"Display help on a single or all commands.\r\n"	\
 			"List of commands:\r\n"				\
-			"CAT, CD, COPY, CREDITS, DELETE, JMP, \r\n"	\
-			"LOAD, MKDIR, RENAME, RUN, SAVE, SET, \r\n"	\
-			"TIME, VDU, TYPE, CLS, MOUNT, HELP.\r\n"
+			"CAT, CD, CLS, COPY, CREDITS, DELETE, EXEC, \r\n"	\
+			"HELP, JMP, LOAD, MKDIR, MOUNT, RENAME, RUN, \r\n"	\
+			"SAVE, SET, TIME, TYPE, VDU.\r\n"
 #define HELP_HELP_ARGS	"[ <command> | all ]"
 
 #endif MOS_H


### PR DESCRIPTION
This suppresses error reporting on processing the autoexec.txt file if the file is not present, as it's OK to _not_ have that file. :grin:

All other errors on attempting to process that file _will_ be shown, so booting a machine with no SD card present will show "SD card failure".  I had been tempted to suppress that error too, but keeping it feels more sensible given that in normal use users should have an SD card inserted.