### PR TITLE
Command history (slightly enhanced)

### DIFF
--- a/main.c
+++ b/main.c
@@ -53,6 +53,9 @@ extern char 			coldBoot;		// 1 = cold boot, 0 = warm boot
 extern volatile	char 	keycode;		// Keycode 
 extern volatile char	gp;				// General poll variable
 
+extern volatile BYTE history_no;
+extern volatile BYTE history_size;
+
 // Wait for the ESP32 to respond with a GP packet to signify it is ready
 // Parameters:
 // - pUART: Pointer to a UART structure
@@ -131,6 +134,8 @@ int main(void) {
 	(void)mos_mount();								// Mount the SD card
 
 	putch(7);										// Startup beep
+	history_no = 0;
+	history_size = 0;
 
 	// Load the autoexec.bat config file
 	//

--- a/src/mos.c
+++ b/src/mos.c
@@ -66,6 +66,8 @@ extern BYTE 	rtc;							// In globals.asm
 static FATFS	fs;					// Handle for the file system
 static char * mos_strtok_ptr;	// Pointer for current position in string tokeniser
 
+extern volatile BYTE history_no;
+
 t_mosFileObject	mosFileObjects[MOS_maxOpenFiles];
 
 // Array of MOS commands and pointer to the C function to run

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -13,6 +13,7 @@
 #define MOS_EDITOR_H
 
 #define cmd_historyWidth	255
+#define cmd_historyDepth	16
 
 UINT24	mos_EDITLINE(char * filename, int bufferLength, UINT8 clear);
 

--- a/src_startup/globals.asm
+++ b/src_startup/globals.asm
@@ -72,6 +72,9 @@
 			XDEF	_vdp_protocol_data
 
 			XDEF	_user_kbvector
+			
+			XDEF	_history_no
+			XDEF	_history_size
 
 			SEGMENT BSS		; This section is reset to 0 in cstartup.asm
 			
@@ -153,6 +156,11 @@ _vdp_protocol_data:	DS	VDPP_BUFFERLEN
 ; Userspace hooks
 ;
 _user_kbvector: 	DS	3		; Pointer to keyboard function
+
+;Cmd history
+
+_history_no:		DS 1
+_history_size:		DS 1
 
 			SECTION DATA		; This section is copied to RAM in cstartup.asm
 


### PR DESCRIPTION
Building on work done by @HeathenUK in #11 this adds a few enhancements

brief summary of changed/enhanced functionality:
if you are at the start of a line and press up, it will go to the previous history item if there is one, otherwise do nothing
if you are somewhere along a line and press up it will either go up a line within the current string or if you’re already at the top line of that string go to the beginning
if you are at the end of a line and press down it will go to the next history item if there is one, otherwise do nothing
if you are somewhere along a line and press down it will either go down a line within the current string, or if you’re already on the bottom line go to the end

you’re always left at the end of a line when moving position in history - this means that you’ll usually need to press up twice to go to a previous entry