### PR TITLE
Add HOTKEY functionality and add support in MOS VDU command for semicolon (long) values.

### DIFF
--- a/main.c
+++ b/main.c
@@ -162,7 +162,7 @@ int main(void) {
 			}
 		}
 		else {
-			printf("%cEscape\n\r", MOS_prompt);
+			printf("%s%cEscape\n\r", cwd, MOS_prompt);
 		}
 	}
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -336,7 +336,38 @@ int mos_cmdKEY(char *ptr) {
 	char *hotkey_string;
 	char *hotkey_string_token;
 
-	mos_parseNumber(NULL, &fn_number);
+	if (!mos_parseNumber(NULL, &fn_number)) {
+		
+		printf("Hotkey assignments:\r\n\r\n");
+		
+		if (hotkey_strings[0] != NULL) printf("F1:  %s\r\n", hotkey_strings[0]);
+			else printf("F1:  N/A\r\n");
+		if (hotkey_strings[1] != NULL) printf("F2:  %s\r\n", hotkey_strings[1]);
+			else printf("F2:  N/A\r\n");
+		if (hotkey_strings[2] != NULL) printf("F3:  %s\r\n", hotkey_strings[2]);
+			else printf("F3:  N/A\r\n");
+		if (hotkey_strings[3] != NULL) printf("F4:  %s\r\n", hotkey_strings[3]);
+			else printf("F4:  N/A\r\n");
+		if (hotkey_strings[4] != NULL) printf("F5:  %s\r\n", hotkey_strings[4]);
+			else printf("F5:  N/A\r\n");
+		if (hotkey_strings[5] != NULL) printf("F6:  %s\r\n", hotkey_strings[5]);
+			else printf("F6:  N/A\r\n");
+		if (hotkey_strings[6] != NULL) printf("F7:  %s\r\n", hotkey_strings[6]);
+			else printf("F7:  N/A\r\n");
+		if (hotkey_strings[7] != NULL) printf("F8:  %s\r\n", hotkey_strings[7]);
+			else printf("F8:  N/A\r\n");
+		if (hotkey_strings[8] != NULL) printf("F9:  %s\r\n", hotkey_strings[8]);
+			else printf("F9:  N/A\r\n");
+		if (hotkey_strings[9] != NULL) printf("F10: %s\r\n", hotkey_strings[9]);
+			else printf("F10: N/A\r\n");
+		if (hotkey_strings[10] != NULL) printf("F11: %s\r\n", hotkey_strings[10]);
+			else printf("F11: N/A\r\n");
+		if (hotkey_strings[11] != NULL) printf("F12: %s\r\n", hotkey_strings[11]);
+			else printf("F12: N/A\r\n");
+				
+		printf("\r\n");
+			
+	}
 
 	if (fn_number < 1 || fn_number > 12) {
 		printf("Invalid FN-key number.\r\n");

--- a/src/mos.c
+++ b/src/mos.c
@@ -55,6 +55,7 @@
 #include "strings.h"
 
 char  	cmd[256];				// Array for the command line handler
+char	cmd_shadow[256];		// Will hold preserved edit line
 
 extern void *	set_vector(unsigned int vector, void(*handler)(void));	// In vectors16.asm
 
@@ -99,6 +100,7 @@ static t_mosCommand mosCommands[] = {
 	{ "CLS",		&mos_cmdCLS,		NULL,			HELP_CLS,	NULL },
 	{ "MOUNT",		&mos_cmdMOUNT,		NULL,			HELP_MOUNT,	NULL },
 	{ "HELP",		&mos_cmdHELP,		HELP_HELP_ARGS,		HELP_HELP,	NULL },
+	{ "KEY",		&mos_cmdKEY,		HELP_KEY_ARGS,		HELP_KEY,	NULL },
 };
 
 #define mosCommands_count (sizeof(mosCommands)/sizeof(t_mosCommand))
@@ -328,6 +330,47 @@ BOOL mos_parseString(char * ptr, char ** p_Value) {
 	return 1;
 }
 
+int mos_cmdKEY(char *ptr) {
+
+	UINT24 fn_number = 0;
+	char *hotkey_string;
+	char *hotkey_string_token;
+
+	mos_parseNumber(NULL, &fn_number);
+
+	if (fn_number < 1 || fn_number > 12) {
+		printf("Invalid FN-key number.\r\n");
+		return 0;
+	}
+
+	if (!mos_parseString(NULL, &hotkey_string)) {
+
+		if (hotkey_strings[fn_number - 1] != NULL) {
+			free(hotkey_strings[fn_number - 1]);
+			hotkey_strings[fn_number - 1] = NULL;
+			printf("F%u cleared.\r\n", fn_number);
+		} else printf("No string hotkey provided.\r\n");
+
+		return 0;
+
+	}
+
+	//"key x " = 6 chars
+	//"key xx " = 7 chars
+
+	if (fn_number < 10)	{
+		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key x ") + 1) * sizeof(char));
+		strncpy(hotkey_strings[fn_number - 1], cmd_shadow + strlen("key x "), strlen(cmd_shadow) - strlen("key x "));
+		hotkey_strings[fn_number - 1][strlen(cmd_shadow) - strlen("key x ")] = '\0';
+	} else {
+		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key xx ") + 1) * sizeof(char));
+		strncpy(hotkey_strings[fn_number - 1], cmd_shadow + strlen("key xx "), strlen(cmd_shadow) - strlen("key xx "));
+		hotkey_strings[fn_number - 1][strlen(cmd_shadow) - strlen("key xx ")] = '\0';
+	}
+
+	return 0;
+}
+
 // Execute a MOS command
 // Parameters:
 // - buffer: Pointer to a zero terminated string that contains the MOS command with arguments
@@ -342,6 +385,9 @@ int mos_exec(char * buffer) {
 	UINT8	mode;
 
 	ptr = mos_trim(buffer);
+	
+	strcpy (cmd_shadow, ptr);
+	
 	ptr = mos_strtok(ptr, " ");
 	if(ptr != NULL) {
 		func = mos_getCommand(ptr);
@@ -1175,7 +1221,6 @@ UINT24 mos_COPY(char * srcPath, char * dstPath) {
 
         fr = f_findfirst(&dir, &fno, srcDir, pattern);
         while (fr == FR_OK && fno.fname[0] != 0) {
-            printf("Copying %s to %s\r\n", fullSrcPath, fullDstPath);
 			
 			sprintf(fullSrcPath, "%s%s", srcDir, fno.fname);
 
@@ -1186,6 +1231,8 @@ UINT24 mos_COPY(char * srcPath, char * dstPath) {
                 sprintf(fullDstPath, "%s/%s", dstPath, fno.fname);
             }
 
+			printf("Copying %s to %s\r\n", fullSrcPath, fullDstPath);
+			
             // File copy operation
             fr = f_open(&fsrc, fullSrcPath, FA_READ);
             if (fr != FR_OK) break;

--- a/src/mos.c
+++ b/src/mos.c
@@ -978,44 +978,75 @@ UINT24	mos_CD(char *path) {
 // Returns:
 // - FatFS return code
 // 
-UINT24	mos_DIR(char * path) {
-	FRESULT	fr;
-	DIR	  	dir;
-	static 	FILINFO  fno;
-	int		yr, mo, da, hr, mi;
-	char 	str[12];
-	
-	fr = f_getlabel("", str, 0);
-	if(fr != 0) {
-		return fr;
-	}	
-	printf("Volume: ");
-	if(strlen(str) > 0) {
-		printf("%s", str);
-	}
-	else {
-		printf("<No Volume Label>");
-	}
-	printf("\n\r\n\r");
-	
-	fr = f_opendir(&dir, path);
-	if(fr == FR_OK) {
-		for(;;) {
-			fr = f_readdir(&dir, &fno);
-			if (fr != FR_OK || fno.fname[0] == 0) {
-				break;  // Break on error or end of dir
-			}
-			yr = (fno.fdate & 0xFE00) >>  9;	// Bits 15 to  9, from 1980
-			mo = (fno.fdate & 0x01E0) >>  5;	// Bits  8 to  5
-			da = (fno.fdate & 0x001F);			// Bits  4 to  0
-			hr = (fno.ftime & 0xF800) >> 11;	// Bits 15 to 11
-			mi = (fno.ftime & 0x07E0) >>  5;	// Bits 10 to  5
-			
-			printf("%04d/%02d/%02d\t%02d:%02d %c %*lu %s\n\r", yr + 1980, mo, da, hr, mi, fno.fattrib & AM_DIR ? 'D' : ' ', 8, fno.fsize, fno.fname);
-		}
-	}
-	f_closedir(&dir);
-	return fr;
+UINT24 mos_DIR(char * inputPath) {
+    FRESULT fr;
+    DIR dir;
+    static FILINFO fno;
+    char dirPath[256], pattern[32] = {0};
+    BOOL usePattern = FALSE;
+    char str[12]; // Buffer for volume label
+    int yr, mo, da, hr, mi;
+
+    fr = f_getlabel("", str, 0);
+    if (fr != 0) {
+        return fr;
+    }
+    printf("Volume: ");
+    if (strlen(str) > 0) {
+        printf("%s", str);
+    } else {
+        printf("<No Volume Label>");
+    }
+    printf("\n\r\n\r");
+
+    if (strchr(inputPath, '/') == NULL && strchr(inputPath, '*') != NULL) {
+        strcpy(dirPath, ".");
+        strcpy(pattern, inputPath);
+        usePattern = TRUE;
+    } else if (strcmp(inputPath, ".") == 0) {
+        strcpy(dirPath, ".");
+    } else {
+        char *lastSeparator = strrchr(inputPath, '/');
+        if (lastSeparator != NULL && *(lastSeparator + 1) != '\0') {
+            strncpy(dirPath, inputPath, lastSeparator - inputPath + 1);
+            dirPath[lastSeparator - inputPath + 1] = '\0';
+            strcpy(pattern, lastSeparator + 1);
+            usePattern = TRUE;
+        } else {
+            strcpy(dirPath, inputPath);
+        }
+    }
+
+    fr = f_opendir(&dir, dirPath);
+    if (fr == FR_OK) {
+        if (usePattern) {
+            fr = f_findfirst(&dir, &fno, dirPath, pattern);
+        } else {
+            fr = f_readdir(&dir, &fno);
+        }
+
+        while (fr == FR_OK && fno.fname[0]) {
+
+            yr = (fno.fdate & 0xFE00) >> 9;  // Bits 15 to  9, from 1980
+            mo = (fno.fdate & 0x01E0) >> 5;  // Bits  8 to  5
+            da = (fno.fdate & 0x001F);       // Bits  4 to  0
+            hr = (fno.ftime & 0xF800) >> 11; // Bits 15 to 11
+            mi = (fno.ftime & 0x07E0) >> 5;  // Bits 10 to  5
+
+            printf("%04d/%02d/%02d\t%02d:%02d %c %*lu %s\n\r", yr + 1980, mo, da, hr, mi, fno.fattrib & AM_DIR ? 'D' : ' ', 8, fno.fsize, fno.fname);
+
+            if (usePattern) {
+                fr = f_findnext(&dir, &fno);
+            } else {
+                fr = f_readdir(&dir, &fno);
+            }
+
+            if (!usePattern && fno.fname[0] == 0) break;
+        }
+    }
+
+    f_closedir(&dir);
+    return fr;
 }
 
 // Delete file

--- a/src/mos.c
+++ b/src/mos.c
@@ -872,11 +872,11 @@ int mos_cmdKEY(char *ptr) {
 	//"key xx " = 7 chars
 	
 	if (fn_number < 10)	{
-		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key x ")) * sizeof(char));
+		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key x ") + 1) * sizeof(char));
 		strncpy(hotkey_strings[fn_number - 1], cmd_shadow + strlen("key x "), strlen(cmd_shadow) - strlen("key x "));
 		hotkey_strings[fn_number - 1][strlen(cmd_shadow) - strlen("key x ")] = '\0';
 	} else {
-		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key xx ")) * sizeof(char));
+		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key xx ") + 1) * sizeof(char));
 		strncpy(hotkey_strings[fn_number - 1], cmd_shadow + strlen("key xx "), strlen(cmd_shadow) - strlen("key xx "));
 		hotkey_strings[fn_number - 1][strlen(cmd_shadow) - strlen("key xx ")] = '\0';
 	}

--- a/src/mos.c
+++ b/src/mos.c
@@ -366,6 +366,7 @@ int mos_cmdKEY(char *ptr) {
 			else printf("F12: N/A\r\n");
 				
 		printf("\r\n");
+		return 0;
 			
 	}
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -664,36 +664,21 @@ int mos_cmdSET(char * ptr) {
 	return 19; // Bad Parameter
 }
 
-// VDU <char1> <long2;> ... <charN>
+// VDU <char1> <char2> ... <charN>
 // Parameters:
 // - ptr: Pointer to the argument string in the line edit buffer
 // Returns:
 // - MOS error code
 //
 int	mos_cmdVDU(char *ptr) {
-	char *value_str;
 	UINT24 	value;
 	
-	while (mos_parseString(NULL, &value_str)) {
-		
-		value = strtol(value_str, NULL, 10);
-		
-		if (value_str[strlen(value_str) - 1] == ';') {
-			
-			putch(value & 0xFF); // write LSB
-			putch(value >> 8);	 // write MSB	
-		
-		} else {
-			
-			if(value > 255) {
-				return 19;	// Bad Parameter
-			}
-			putch(value);
-			
+	while(mos_parseNumber(NULL, &value)) {
+		if(value > 255) {
+			return 19;	// Bad Parameter
 		}
-		
+		putch(value);
 	}
-	
 	return 0;
 }
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -664,21 +664,36 @@ int mos_cmdSET(char * ptr) {
 	return 19; // Bad Parameter
 }
 
-// VDU <char1> <char2> ... <charN>
+// VDU <char1> <long2;> ... <charN>
 // Parameters:
 // - ptr: Pointer to the argument string in the line edit buffer
 // Returns:
 // - MOS error code
 //
 int	mos_cmdVDU(char *ptr) {
+	char *value_str;
 	UINT24 	value;
 	
-	while(mos_parseNumber(NULL, &value)) {
-		if(value > 255) {
-			return 19;	// Bad Parameter
+	while (mos_parseString(NULL, &value_str)) {
+		
+		value = strtol(value_str, NULL, 10);
+		
+		if (value_str[strlen(value_str) - 1] == ';') {
+			
+			putch(value & 0xFF); // write LSB
+			putch(value >> 8);	 // write MSB	
+		
+		} else {
+			
+			if(value > 255) {
+				return 19;	// Bad Parameter
+			}
+			putch(value);
+			
 		}
-		putch(value);
+		
 	}
+	
 	return 0;
 }
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -858,11 +858,14 @@ int mos_cmdKEY(char *ptr) {
 	
 	if (!mos_parseString(NULL, &hotkey_string)) {
 		
-		free(hotkey_strings[fn_number - 1]);
-		hotkey_strings[fn_number - 1] = NULL;
+		if (hotkey_strings[fn_number - 1] != NULL) {
+			free(hotkey_strings[fn_number - 1]);
+			hotkey_strings[fn_number - 1] = NULL;
+			printf("F%u cleared.\r\n", fn_number);
+		} else printf("No string hotkey provided.\r\n");
 		
-		printf("F%u cleared.\r\n", fn_number);
 		return 0;
+		
 	}
 	
 	//"key x " = 6 chars

--- a/src/mos.c
+++ b/src/mos.c
@@ -978,75 +978,44 @@ UINT24	mos_CD(char *path) {
 // Returns:
 // - FatFS return code
 // 
-UINT24 mos_DIR(char * inputPath) {
-    FRESULT fr;
-    DIR dir;
-    static FILINFO fno;
-    char dirPath[256], pattern[32] = {0};
-    BOOL usePattern = FALSE;
-    char str[12]; // Buffer for volume label
-    int yr, mo, da, hr, mi;
-
-    fr = f_getlabel("", str, 0);
-    if (fr != 0) {
-        return fr;
-    }
-    printf("Volume: ");
-    if (strlen(str) > 0) {
-        printf("%s", str);
-    } else {
-        printf("<No Volume Label>");
-    }
-    printf("\n\r\n\r");
-
-    if (strchr(inputPath, '/') == NULL && strchr(inputPath, '*') != NULL) {
-        strcpy(dirPath, ".");
-        strcpy(pattern, inputPath);
-        usePattern = TRUE;
-    } else if (strcmp(inputPath, ".") == 0) {
-        strcpy(dirPath, ".");
-    } else {
-        char *lastSeparator = strrchr(inputPath, '/');
-        if (lastSeparator != NULL && *(lastSeparator + 1) != '\0') {
-            strncpy(dirPath, inputPath, lastSeparator - inputPath + 1);
-            dirPath[lastSeparator - inputPath + 1] = '\0';
-            strcpy(pattern, lastSeparator + 1);
-            usePattern = TRUE;
-        } else {
-            strcpy(dirPath, inputPath);
-        }
-    }
-
-    fr = f_opendir(&dir, dirPath);
-    if (fr == FR_OK) {
-        if (usePattern) {
-            fr = f_findfirst(&dir, &fno, dirPath, pattern);
-        } else {
-            fr = f_readdir(&dir, &fno);
-        }
-
-        while (fr == FR_OK && fno.fname[0]) {
-
-            yr = (fno.fdate & 0xFE00) >> 9;  // Bits 15 to  9, from 1980
-            mo = (fno.fdate & 0x01E0) >> 5;  // Bits  8 to  5
-            da = (fno.fdate & 0x001F);       // Bits  4 to  0
-            hr = (fno.ftime & 0xF800) >> 11; // Bits 15 to 11
-            mi = (fno.ftime & 0x07E0) >> 5;  // Bits 10 to  5
-
-            printf("%04d/%02d/%02d\t%02d:%02d %c %*lu %s\n\r", yr + 1980, mo, da, hr, mi, fno.fattrib & AM_DIR ? 'D' : ' ', 8, fno.fsize, fno.fname);
-
-            if (usePattern) {
-                fr = f_findnext(&dir, &fno);
-            } else {
-                fr = f_readdir(&dir, &fno);
-            }
-
-            if (!usePattern && fno.fname[0] == 0) break;
-        }
-    }
-
-    f_closedir(&dir);
-    return fr;
+UINT24	mos_DIR(char * path) {
+	FRESULT	fr;
+	DIR	  	dir;
+	static 	FILINFO  fno;
+	int		yr, mo, da, hr, mi;
+	char 	str[12];
+	
+	fr = f_getlabel("", str, 0);
+	if(fr != 0) {
+		return fr;
+	}	
+	printf("Volume: ");
+	if(strlen(str) > 0) {
+		printf("%s", str);
+	}
+	else {
+		printf("<No Volume Label>");
+	}
+	printf("\n\r\n\r");
+	
+	fr = f_opendir(&dir, path);
+	if(fr == FR_OK) {
+		for(;;) {
+			fr = f_readdir(&dir, &fno);
+			if (fr != FR_OK || fno.fname[0] == 0) {
+				break;  // Break on error or end of dir
+			}
+			yr = (fno.fdate & 0xFE00) >>  9;	// Bits 15 to  9, from 1980
+			mo = (fno.fdate & 0x01E0) >>  5;	// Bits  8 to  5
+			da = (fno.fdate & 0x001F);			// Bits  4 to  0
+			hr = (fno.ftime & 0xF800) >> 11;	// Bits 15 to 11
+			mi = (fno.ftime & 0x07E0) >>  5;	// Bits 10 to  5
+			
+			printf("%04d/%02d/%02d\t%02d:%02d %c %*lu %s\n\r", yr + 1980, mo, da, hr, mi, fno.fattrib & AM_DIR ? 'D' : ' ', 8, fno.fsize, fno.fname);
+		}
+	}
+	f_closedir(&dir);
+	return fr;
 }
 
 // Delete file

--- a/src/mos.h
+++ b/src/mos.h
@@ -87,6 +87,7 @@ int		mos_cmdTYPE(char *ptr);
 int		mos_cmdCLS(char *ptr);
 int		mos_cmdMOUNT(char *ptr);
 int		mos_cmdHELP(char *ptr);
+int		mos_cmdHOTKEY(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
@@ -202,5 +203,9 @@ UINT8	fat_EOF(FIL * fp);
 							"HELP, JMP, LOAD, MKDIR, MOUNT, RENAME, RUN, \r\n"	\
 							"SAVE, SET, TIME, TYPE, VDU.\r\n"
 #define HELP_HELP_ARGS		"[ <command> | all ]"
+
+#define HELP_HOTKEY			"Assign a string to the specified FN hotkey.\r\n"
+
+#define HELP_HOTKEY_ARGS	"[FN key number (1-12)] [String]\r\n"
 
 #endif MOS_H

--- a/src/mos.h
+++ b/src/mos.h
@@ -37,6 +37,7 @@
 #include "ff.h"
 
 extern char  	cmd[256];				// Array for the command line handler
+extern TCHAR	cwd[256];
 
 typedef struct {
 	char * name;
@@ -70,6 +71,7 @@ BOOL	mos_parseString(char * ptr, char ** p_Value);
 
 int		mos_cmdDIR(char * ptr);
 int		mos_cmdLOAD(char * ptr);
+int		mos_cmdCHAIN(char *ptr);
 int		mos_cmdSAVE(char *ptr);
 int		mos_cmdDEL(char * ptr);
 int		mos_cmdJMP(char * ptr);

--- a/src/mos.h
+++ b/src/mos.h
@@ -87,7 +87,7 @@ int		mos_cmdTYPE(char *ptr);
 int		mos_cmdCLS(char *ptr);
 int		mos_cmdMOUNT(char *ptr);
 int		mos_cmdHELP(char *ptr);
-int		mos_cmdHOTKEY(char *ptr);
+int		mos_cmdKEY(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
@@ -204,8 +204,9 @@ UINT8	fat_EOF(FIL * fp);
 							"SAVE, SET, TIME, TYPE, VDU.\r\n"
 #define HELP_HELP_ARGS		"[ <command> | all ]"
 
-#define HELP_HOTKEY			"Assign a string to the specified FN hotkey.\r\n"
-
-#define HELP_HOTKEY_ARGS	"[FN key number (1-12)] [String]\r\n"
+#define HELP_KEY			"Assign a string to the specified FN hotkey.\r\n"
+	
+#define HELP_KEY_ARGS		"KEY [FN key number (1-12)] [String] to set a hotkey's string\r\n" \
+							"KEY [FN key number (1-12)] to unset.\r\n"
 
 #endif MOS_H

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -449,15 +449,19 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								
 								//printf("Path:\"%s\" Pattern:\"%s\"\r\n", path, search_term);
 								fr = f_findfirst(&dj, &fno, path, search_term);
+								
+								if (fr == FR_OK && fno.fname[0]) {
 
-								if (fno.fattrib & AM_DIR) printf("%s/", fno.fname + strlen(search_term) - 1);
-								else printf("%s", fno.fname + strlen(search_term) - 1);
+									if (fno.fattrib & AM_DIR) printf("%s/", fno.fname + strlen(search_term) - 1);
+									else printf("%s", fno.fname + strlen(search_term) - 1);
 
-								strcat(buffer, fno.fname + strlen(search_term) - 1);
-								if (fno.fattrib & AM_DIR) strcat(buffer, "/");
+									strcat(buffer, fno.fname + strlen(search_term) - 1);
+									if (fno.fattrib & AM_DIR) strcat(buffer, "/");
 
-								len = strlen(buffer);
-								insertPos = strlen(buffer);
+									len = strlen(buffer);
+									insertPos = strlen(buffer);
+									
+								}
 
 								// Free the allocated memory
 								free(search_term);

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -42,7 +42,7 @@ extern BYTE scrcols;
 // Storage for the command history
 //
 static char	cmd_history[cmd_historyDepth][cmd_historyWidth + 1];
-char hotkey_strings[12][cmd_historyWidth + 1] = {'\0'}; 
+char *hotkey_strings[12] = NULL; 
 
 // Get the current cursor position from the VPD
 //
@@ -257,7 +257,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 			case 0xA9: //F11	
 			case 0xAA: //F12
 			{
-				if (hotkey_strings[keyc - 159][0] != '\0') {
+				if (hotkey_strings[keyc - 159] != NULL) {
 					removeEditLine(buffer, insertPos, len);
 					strcpy(buffer, hotkey_strings[keyc - 159]);
 					printf("%s", buffer);

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -43,6 +43,7 @@ extern BYTE scrcols;
 // Storage for the command history
 //
 static char	cmd_history[cmd_historyDepth][cmd_historyWidth + 1];
+char *hotkey_strings[12] = NULL; 
 
 // Get the current cursor position from the VPD
 //
@@ -241,6 +242,66 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 			case 0x87: {	// END
 				insertPos = gotoEditLineEnd(insertPos, len);
 			} break;
+			
+			case 0x9F: //F1
+			case 0xA0: //F2
+			case 0xA1: //F3
+			case 0xA2: //F4
+			case 0xA3: //F5
+			case 0xA4: //F6
+			case 0xA5: //F7
+			case 0xA6: //F8
+			case 0xA7: //F9
+			case 0xA8: //F10
+			case 0xA9: //F11	
+			case 0xAA: //F12
+			{
+				if (hotkey_strings[keyc - 159] != NULL) {
+
+					char *wildcardPos = strstr(hotkey_strings[keyc - 159], "%s");
+
+					if (wildcardPos == NULL) { //No wildcard in the hotkey string
+
+						removeEditLine(buffer, insertPos, len);
+						strcpy(buffer, hotkey_strings[keyc - 159]);
+						printf("%s", buffer);
+						len = strlen(buffer);
+						insertPos = len;
+						keya = 0x0D;
+					} else {
+
+						UINT8 prefixLength = wildcardPos - hotkey_strings[keyc - 159];
+						UINT8 replacementLength = strlen(buffer);
+						UINT8 suffixLength = strlen(wildcardPos + 2);
+						char *result;
+
+						if (prefixLength + replacementLength + suffixLength + 1 >= bufferLength) {
+							break;  // Exceeds max command length (256 chars)
+						}
+
+						result = malloc(prefixLength + replacementLength + suffixLength + 1); // +1 for null terminator
+
+						strncpy(result, hotkey_strings[keyc - 159], prefixLength); //Copy the portion preceding the wildcard to the buffer
+						result[prefixLength] = '\0'; //Terminate
+
+						strcat(result, buffer);
+						strcat(result, wildcardPos + 2);
+
+						removeEditLine(buffer, insertPos, len);
+						strcpy(buffer, result);
+						printf("%s", buffer);
+						len = strlen(buffer);
+						insertPos = len;
+						
+						keya = 0x0D;
+
+						free(result);
+
+					}
+
+				} else break;
+			}			
+			
 			//
 			// Now the ASCII keys
 			//

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -388,6 +388,67 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									}
 								}
 							} break;
+							
+							case 0x09: {
+							
+								const char *tempPtr = buffer;
+								const char *search_pos = NULL;
+								char *search_term;
+								
+								FRESULT fr;
+								DIR dj;
+								FILINFO fno;
+
+								while (*tempPtr != '\0') {
+									if (*tempPtr == ' ' || *tempPtr == '"') {
+										search_pos = tempPtr + 1; // Point to the character after the space
+									}
+									tempPtr++;
+								}
+
+								if (search_pos != NULL) {
+									
+									search_term = (char*) malloc(strlen(search_pos) + 2);
+									if (search_term == NULL) {
+										printf("Memory allocation failed.\n");
+										return 1;
+									}
+
+									strcpy(search_term, search_pos);
+									strcat(search_term, "*");
+
+									fr = f_findfirst(&dj, &fno, "", search_term);
+									
+									printf("%s", fno.fname + strlen(search_pos));
+									
+									strcat(buffer, fno.fname + strlen(search_pos));
+									
+									len = strlen(buffer);
+									insertPos = strlen(buffer);
+									
+									free(search_term);
+								} else { //No space, probably the only thing on the line.
+									
+									search_term = (char*) malloc(strlen(buffer) + 2);
+									strcpy(search_term, buffer);
+									strcat(search_term, "*");
+									
+									fr = f_findfirst(&dj, &fno, "", search_term);
+									
+									printf("%s", fno.fname + strlen(buffer));
+									
+									strcat(buffer, fno.fname + strlen(buffer));
+									
+									len = strlen(buffer);
+									insertPos = strlen(buffer);
+									
+									free(search_term);									
+									
+								}
+								
+
+							} break;
+							
 							case 0x7F: {	// Backspace
 								if (deleteCharacter(buffer, insertPos, len)) {
 									insertPos--;

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -42,6 +42,7 @@ extern BYTE scrcols;
 // Storage for the command history
 //
 static char	cmd_history[cmd_historyDepth][cmd_historyWidth + 1];
+char hotkey_strings[12][cmd_historyWidth + 1] = {'\0'}; 
 
 // Get the current cursor position from the VPD
 //
@@ -234,12 +235,38 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 			//
 			// First any extended (non-ASCII keys)
 			//
+			
 			case 0x85: {	// HOME
 				insertPos = gotoEditLineStart(insertPos);
 			} break;
 			case 0x87: {	// END
 				insertPos = gotoEditLineEnd(insertPos, len);
 			} break;
+			
+			
+			case 0x9F: //F1
+			case 0xA0: //F2
+			case 0xA1: //F3
+			case 0xA2: //F4
+			case 0xA3: //F5
+			case 0xA4: //F6
+			case 0xA5: //F7
+			case 0xA6: //F8
+			case 0xA7: //F9
+			case 0xA8: //F10
+			case 0xA9: //F11	
+			case 0xAA: //F12
+			{
+				if (hotkey_strings[keyc - 159][0] != '\0') {
+					removeEditLine(buffer, insertPos, len);
+					strcpy(buffer, hotkey_strings[keyc - 159]);
+					printf("%s", buffer);
+					len = strlen(buffer);
+					insertPos = len;
+					keya = 0x0D;
+				} else break;
+			}
+			
 			//
 			// Now the ASCII keys
 			//

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -388,67 +388,6 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									}
 								}
 							} break;
-							
-							case 0x09: {
-							
-								const char *tempPtr = buffer;
-								const char *search_pos = NULL;
-								char *search_term;
-								
-								FRESULT fr;
-								DIR dj;
-								FILINFO fno;
-
-								while (*tempPtr != '\0') {
-									if (*tempPtr == ' ' || *tempPtr == '"') {
-										search_pos = tempPtr + 1; // Point to the character after the space
-									}
-									tempPtr++;
-								}
-
-								if (search_pos != NULL) {
-									
-									search_term = (char*) malloc(strlen(search_pos) + 2);
-									if (search_term == NULL) {
-										printf("Memory allocation failed.\n");
-										return 1;
-									}
-
-									strcpy(search_term, search_pos);
-									strcat(search_term, "*");
-
-									fr = f_findfirst(&dj, &fno, "", search_term);
-									
-									printf("%s", fno.fname + strlen(search_pos));
-									
-									strcat(buffer, fno.fname + strlen(search_pos));
-									
-									len = strlen(buffer);
-									insertPos = strlen(buffer);
-									
-									free(search_term);
-								} else { //No space, probably the only thing on the line.
-									
-									search_term = (char*) malloc(strlen(buffer) + 2);
-									strcpy(search_term, buffer);
-									strcat(search_term, "*");
-									
-									fr = f_findfirst(&dj, &fno, "", search_term);
-									
-									printf("%s", fno.fname + strlen(buffer));
-									
-									strcat(buffer, fno.fname + strlen(buffer));
-									
-									len = strlen(buffer);
-									insertPos = strlen(buffer);
-									
-									free(search_term);									
-									
-								}
-								
-
-							} break;
-							
 							case 0x7F: {	// Backspace
 								if (deleteCharacter(buffer, insertPos, len)) {
 									insertPos--;

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -416,8 +416,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 
 									path = (char*) malloc(pathLength + 1); // +1 for null terminator
 									if (path == NULL) {
-										printf("Memory allocation failed.\n");
-										return 1;
+										break;
 									}
 									strncpy(path, lastSpace, pathLength); // Start after the last space
 									path[pathLength] = '\0'; // Null-terminate the string
@@ -432,7 +431,6 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									
 									path = (char*) malloc(1);
 									if (path == NULL) {
-										printf("Memory allocation for no path failed.\n");
 										break;
 									}
 									path[0] = '\0'; // Path is empty (current dir, essentially).
@@ -442,9 +440,8 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								}
 
 								if (search_term == NULL) {
-									printf("Memory allocation failed.\n");
 									free(path);
-									return 1;
+									break;
 								}
 
 								strcpy(search_term, lastSpace && lastSlash > lastSpace ? lastSlash + 1 : lastSpace ? lastSpace + 1 : buffer);

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -17,4 +17,6 @@
 
 UINT24	mos_EDITLINE(char * filename, int bufferLength, UINT8 clear);
 
+extern char	hotkey_strings[12][cmd_historyWidth + 1];
+
 #endif MOS_EDITOR_H

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -17,6 +17,6 @@
 
 UINT24	mos_EDITLINE(char * filename, int bufferLength, UINT8 clear);
 
-extern char	hotkey_strings[12][cmd_historyWidth + 1];
+extern char	*hotkey_strings[12];
 
 #endif MOS_EDITOR_H

--- a/src_fatfs/ffconf.h
+++ b/src_fatfs/ffconf.h
@@ -39,7 +39,7 @@
 /   3: f_lseek() function is removed in addition to 2. */
 
 
-#define FF_USE_FIND		0
+#define FF_USE_FIND		1
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 

--- a/src_fatfs/ffconf.h
+++ b/src_fatfs/ffconf.h
@@ -39,7 +39,7 @@
 /   3: f_lseek() function is removed in addition to 2. */
 
 
-#define FF_USE_FIND		1
+#define FF_USE_FIND		0
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 


### PR DESCRIPTION
This PR seeks to add the ability to assign a command string to keys F1 to F12. It hooks in to mos_EDITLINE and therefore supports anything that calls on that function for input handling including both MOS itself and BBC BASIC.

Welcome thoughts on the implementation. This works well but relies on creating thirteen _more_ 256 byte-wide strings to store first a preserved, untokenised command line, and then twelve more for each potential hotkey command. That's 3.3K of RAM on top of the 4K we already reserve for command line history. Perhaps that's fine with 512KB to spare, but it seems wasteful. I considered mallocing each buffer as it's used but it's challenging to determine where you'd free them.

It also makes a tweak to the MOS internal VDU command to bring it in line with BASIC notation (; meaning to treat the preceding as a 16-bit value). Commas are optional for chars. Ignore the commit reverting this, I hate Git.