### PR TITLE
Ignore commands that start with #

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -340,6 +340,9 @@ int mos_exec(char * buffer) {
 	UINT8	mode;
 
 	ptr = mos_trim(buffer);
+	if (ptr != NULL && *ptr == '#') {
+	    return fr;
+	}
 	ptr = mos_strtok(ptr, " ");
 	if(ptr != NULL) {
 		func = mos_getCommand(ptr);


### PR DESCRIPTION
Simple way to implement commenting out an entire line in autoexec.txt or even on the command line. Maybe `REM` is more...historically accurate? But `#` is much shorter :)

Fixes https://github.com/AgonConsole8/agon-mos/issues/19