### PR TITLE
Rainbow neu

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Part of the official firmware for the [Agon Console8](https://www.heber.co.uk/agon-console8)
 
-This firmware is intended for use on the Agon Console8, but should be fully compatible with other Agon Light hardware.  As well as the Console8, it has been tested on the Olimex Agon Light 2.
+This firmware is intended for use on any Agon Light compatible computer.  As well as the Agon Console8, it has been tested on the Olimex Agon Light 2.
 
 This version of agon-mos may differ from the [official Quark firmware](https://github.com/breakintoprogram/agon-mos) and contain some extensions, but software written for the official Quark firmware should be fully compatible with this version.
 
@@ -69,9 +69,9 @@ Unless you are using the ZDS II tools to program the eZ80 directly, it is recomm
 
 The MOS can also be flashed on your device using the [agon-flash Agon MOS firmware upgrade utility](https://github.com/envenomator/agon-flash).  This is a command line utility that runs on the Agon itself, and can flash MOS to the eZ80 from a file stored on your SD card.
 
-In the event that you flash a MOS that does not work, you will need to revert your Agon back to a known working version.  This can be done using the [agon-vdpflash utility](https://github.com/envenomator/agon-vdpflash).  
+In the event that you flash a MOS that does not work, you will need to revert your Agon back to a known working version.  With the exception of the Agon Console8, this can be done using the [agon-vdpflash utility](https://github.com/envenomator/agon-vdpflash).  
 
-NB At this time to use this utility on an Agon Console8 you may need to use an external ESP32-based machine, or make some physical modifications to your Agon Console8.  Generally speaking this is not recommended unless you are an advanced user, and should only be necessary in only the most exceptional circumstances.  This is a developing situation and may change in the future, so you are advised to consult with the community on Discord.
+Recovery for an Agon Console8 requires the use of a second external ESP32-based machine.  Guidance on this, and a tool for recovery, can be found in the [Agon Console8 Recovery Tool](https://github.com/envenomator/console8-recover) repository.
 
 It is recommended when using the agon-flash utility that you use a filename other than `MOS.bin` for your new experimental MOS version, and keep a known working version of the `MOS.bin` file in the root of your SD card, as this is the file that the agon-vdpflash utility uses.
 
@@ -93,9 +93,7 @@ Other options for programming the Agon are available, and the community will be 
 
 ### Documentation
 
-The Agon Light documentation can now be found on the [Agon Light Documentation Wiki](https://github.com/breakintoprogram/agon-docs/wiki)
-
-Documentation for the Agon Console8 is currently being worked on.
+The Agon Platform documentation can now be found on the [Community Documentation](https://agonconsole8.github.io/agon-docs/) site.  This site provides extensive documentation about the Agon platform firmware, covering both Quark and Console8 firmware releases.
 
 ### Community
 

--- a/main.c
+++ b/main.c
@@ -156,7 +156,7 @@ int main(void) {
 	//
 	while(1) {
 		if(mos_input(&cmd, sizeof(cmd)) == 13) {
-			int err = mos_exec(&cmd);
+			int err = mos_exec(&cmd, TRUE);
 			if(err > 0) {
 				mos_error(err);
 			}

--- a/main.c
+++ b/main.c
@@ -174,7 +174,7 @@ int main(void) {
 			}
 		}
 		else {
-			printf("%s%cEscape\n\r", cwd, MOS_prompt);
+			printf("Escape\n\r");
 		}
 	}
 

--- a/main.c
+++ b/main.c
@@ -46,6 +46,9 @@
 #include "mos.h"
 #include "i2c.h"
 
+extern BYTE scrcolours;               // In globals.asm
+
+extern void getModeInformation(void);
 extern void *	set_vector(unsigned int vector, void(*handler)(void));
 
 extern void 	vblank_handler(void);
@@ -122,6 +125,11 @@ int main(void) {
 	if(coldBoot == 0) {								// If a warm boot detected then
 		putch(12);									// Clear the screen
 	}
+
+	scrcolours = 0;
+	getModeInformation();
+	while (scrcolours == 0) {}
+
 	printf("Agon %s MOS Version %d.%d.%d", VERSION_VARIANT, VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH);
 	#if VERSION_CANDIDATE > 0
 		printf(" %s%d", VERSION_TYPE, VERSION_CANDIDATE);

--- a/main.c
+++ b/main.c
@@ -155,13 +155,13 @@ int main(void) {
 
 	// Load the autoexec.bat config file
 	//
-	#if enable_config == 1	
-	if(coldBoot > 0) {								// Check it's a cold boot (after reset, not RST 00h)
+	#if enable_config == 1
+	{
 		int err = mos_EXEC("autoexec.txt", cmd, sizeof cmd);	// Then load and run the config file
 		if (err > 0 && err != FR_NO_FILE) {
 			mos_error(err);
 		}
-	}	
+	}
 	#endif
 
 	// The main loop

--- a/main.c
+++ b/main.c
@@ -134,6 +134,10 @@ int main(void) {
 	#if VERSION_CANDIDATE > 0
 		printf(" %s%d", VERSION_TYPE, VERSION_CANDIDATE);
 	#endif
+	// Show version subtitle, if we have one
+	#ifdef VERSION_SUBTITLE
+		printf(" %s", VERSION_SUBTITLE);
+	#endif
 	// Show build if defined (intended to be auto-generated string from build script from git commit hash)
 	#ifdef VERSION_BUILD
 		printf(" Build %s", VERSION_BUILD);

--- a/main.c
+++ b/main.c
@@ -162,7 +162,7 @@ int main(void) {
 			}
 		}
 		else {
-			printf("%cEscape\n\r", MOS_prompt);
+			printf("%s%cEscape\n\r", cwd, MOS_prompt);
 		}
 	}
 

--- a/src/defines.h
+++ b/src/defines.h
@@ -26,6 +26,7 @@
 #define VDP_mode				0x86
 #define VDP_rtc					0x87
 #define VDP_keystate			0x88
+#define VDP_palette             0x94
 #define VDP_logicalcoords		0xC0
 #define VDP_consolemode			0xFE
 #define VDP_terminalmode		0xFF

--- a/src/mos.c
+++ b/src/mos.c
@@ -93,7 +93,7 @@ static t_mosCommand mosCommands[] = {
 	{ "LOAD",		&mos_cmdLOAD,		HELP_LOAD_ARGS,		HELP_LOAD },
 	{ "LS",			&mos_cmdDIR,		HELP_CAT_ARGS,		HELP_CAT },
 	{ "JMP",		&mos_cmdJMP,		HELP_JMP_ARGS,		HELP_JMP },
-    { "KEY",		&mos_cmdKEY,		HELP_KEY_ARGS,		HELP_KEY },
+    { "HOTKEY",		&mos_cmdHOTKEY,		HELP_HOTKEY_ARGS,	HELP_HOTKEY },
 	{ "MKDIR", 		&mos_cmdMKDIR,		HELP_MKDIR_ARGS,	HELP_MKDIR },
 	{ "MOUNT",		&mos_cmdMOUNT,		NULL,			HELP_MOUNT },
 	{ "MOVE",		&mos_cmdREN,		HELP_RENAME_ARGS,	HELP_RENAME },
@@ -504,13 +504,13 @@ int mos_cmdDIR(char * ptr) {
  	return mos_DIR(path, longListing);
 }
 
-// KEY command
+// HOTKEY command
 // Parameters:
 // - ptr: Pointer to the argument string in the line edit buffer
 // Returns:
 // - MOS error code
 //
-int mos_cmdKEY(char *ptr) {
+int mos_cmdHOTKEY(char *ptr) {
 	UINT24 fn_number = 0;
 	char *hotkey_string;
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -642,7 +642,7 @@ int mos_cmdSET(char * ptr) {
 	) {
 		return 19; // Bad Parameter
 	}
-	if(strcmp(command, "KEYBOARD") == 0 && value <= 8) {
+	if(strcmp(command, "KEYBOARD") == 0 && value <= 15) {
 		putch(23);
 		putch(0);
 		putch(VDP_keycode);

--- a/src/mos.c
+++ b/src/mos.c
@@ -1386,6 +1386,8 @@ UINT8 fat_EOF(FIL * fp) {
 // - fatfs error code
 //
 int mos_mount(void) {
-	return f_mount(&fs, "", 1);			// Mount the SD card
+	int ret = f_mount(&fs, "", 1);			// Mount the SD card
+	f_getcwd(cwd, sizeof(cwd)); //Update full path.
+	return ret;
 }
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -436,9 +436,10 @@ int mos_cmdKEY(char *ptr) {
 
 	if (!mos_parseNumber(NULL, &fn_number)) {
 		
+		UINT8 key;
 		printf("Hotkey assignments:\r\n\r\n");
 		
-		for (int key = 0; key < 12; key++) {
+		for (key = 0; key < 12; key++) {
 				printf("F%d: %s\r\n", key+1, hotkey_strings[key] == NULL ? "N/A" : hotkey_strings[key]);
 		}
 				

--- a/src/mos.c
+++ b/src/mos.c
@@ -642,14 +642,14 @@ int mos_cmdSET(char * ptr) {
 	) {
 		return 19; // Bad Parameter
 	}
-	if(strcmp(command, "KEYBOARD") == 0 && value <= 15) {
+	if(strcasecmp(command, "KEYBOARD") == 0 && value <= 15) {
 		putch(23);
 		putch(0);
 		putch(VDP_keycode);
 		putch(value & 0xFF);
 		return 0;
 	}
-	if(strcmp(command, "CONSOLE") == 0 && value <= 1) {
+	if(strcasecmp(command, "CONSOLE") == 0 && value <= 1) {
 		putch(23);
 		putch(0);
 		putch(VDP_consolemode);

--- a/src/mos.c
+++ b/src/mos.c
@@ -177,16 +177,17 @@ UINT24 mos_input(char * buffer, int bufferLength) {
 // Returns:
 // - Function pointer, or 0 if command not found
 //
-void * mos_getCommand(char * ptr) {
+t_mosCommand *mos_getCommand(char * ptr) {
 	int	   i;
 	t_mosCommand * cmd;	
 	for(i = 0; i < mosCommands_count; i++) {
 		cmd = &mosCommands[i];
 		if(mos_cmp(cmd->name, ptr) == 0) {
-			return cmd->func;
+			//return cmd->func;
+			return cmd;
 		}
 	}
-	return 0;
+	return NULL;
 }
 
 // Case insensitive commpare with abbreviations
@@ -370,6 +371,7 @@ int mos_exec(char * buffer) {
 	int 	(*func)(char * ptr);
 	char	path[256];
 	UINT8	mode;
+	t_mosCommand *cmd;
 
 	ptr = mos_trim(buffer);
 	if (ptr != NULL && *ptr == '#') {
@@ -378,8 +380,9 @@ int mos_exec(char * buffer) {
 
 	ptr = mos_strtok(ptr, " ");
 	if(ptr != NULL) {
-		func = mos_getCommand(ptr);
-		if(func != 0) {
+		cmd = mos_getCommand(ptr);
+		func = cmd->func;
+		if(cmd != NULL && func != 0) {
 			fr = func(ptr);
 		}
 		else {		

--- a/src/mos.c
+++ b/src/mos.c
@@ -162,6 +162,7 @@ BYTE mos_getkey() {
 }
 
 // Call the line editor from MOS
+// Used by main loop to get input from the user
 // Parameters:
 // - buffer: Pointer to the line edit buffer
 // - bufferLength: Size of the line edit buffer in bytes
@@ -170,8 +171,8 @@ BYTE mos_getkey() {
 //
 UINT24 mos_input(char * buffer, int bufferLength) {
 	INT24 retval;
-	printf("%s%c", cwd, MOS_prompt);
-	retval = mos_EDITLINE(buffer, bufferLength, 1);
+	printf("%s %c", cwd, MOS_prompt);
+	retval = mos_EDITLINE(buffer, bufferLength, 3);
 	printf("\n\r");
 	return retval;
 }

--- a/src/mos.c
+++ b/src/mos.c
@@ -340,6 +340,9 @@ int mos_exec(char * buffer) {
 	UINT8	mode;
 
 	ptr = mos_trim(buffer);
+	if (ptr != NULL && *ptr == '#') {
+	    return fr;
+	}
 	ptr = mos_strtok(ptr, " ");
 	if(ptr != NULL) {
 		func = mos_getCommand(ptr);

--- a/src/mos.c
+++ b/src/mos.c
@@ -64,8 +64,6 @@ extern volatile	BYTE keyascii;					// In globals.asm
 extern volatile	BYTE vpd_protocol_flags;		// In globals.asm
 extern BYTE 	rtc;							// In globals.asm
 
-char	cmd_shadow[256];		// Will hold preserved edit line
-
 static FATFS	fs;					// Handle for the file system
 static char * 	mos_strtok_ptr;		// Pointer for current position in string tokeniser
 
@@ -348,9 +346,7 @@ int mos_exec(char * buffer) {
 	if (ptr != NULL && *ptr == '#') {
 	    return fr;
 	}
-	
-	strcpy (cmd_shadow, ptr);
-	
+
 	ptr = mos_strtok(ptr, " ");
 	if(ptr != NULL) {
 		func = mos_getCommand(ptr);
@@ -429,23 +425,19 @@ int mos_cmdDIR(char * ptr) {
 // - MOS error code
 //
 int mos_cmdKEY(char *ptr) {
-
 	UINT24 fn_number = 0;
 	char *hotkey_string;
-	char *hotkey_string_token;
 
 	if (!mos_parseNumber(NULL, &fn_number)) {
-		
 		UINT8 key;
 		printf("Hotkey assignments:\r\n\r\n");
-		
+
 		for (key = 0; key < 12; key++) {
 				printf("F%d: %s\r\n", key+1, hotkey_strings[key] == NULL ? "N/A" : hotkey_strings[key]);
 		}
-				
+
 		printf("\r\n");
 		return 0;
-			
 	}
 
 	if (fn_number < 1 || fn_number > 12) {
@@ -453,30 +445,26 @@ int mos_cmdKEY(char *ptr) {
 		return 0;
 	}
 
-	if (!mos_parseString(NULL, &hotkey_string)) {
-
+	if (strlen(mos_strtok_ptr) < 1) {		
 		if (hotkey_strings[fn_number - 1] != NULL) {
 			free(hotkey_strings[fn_number - 1]);
 			hotkey_strings[fn_number - 1] = NULL;
 			printf("F%u cleared.\r\n", fn_number);
-		} else printf("No string hotkey provided.\r\n");
-
+		} else printf("F%u already clear, no hotkey command provided.\r\n", fn_number);
+		
 		return 0;
-
 	}
 
-	//"key x " = 6 chars
-	//"key xx " = 7 chars
-
-	if (fn_number < 10)	{
-		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key x ") + 1) * sizeof(char));
-		strncpy(hotkey_strings[fn_number - 1], cmd_shadow + strlen("key x "), strlen(cmd_shadow) - strlen("key x "));
-		hotkey_strings[fn_number - 1][strlen(cmd_shadow) - strlen("key x ")] = '\0';
-	} else {
-		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key xx ") + 1) * sizeof(char));
-		strncpy(hotkey_strings[fn_number - 1], cmd_shadow + strlen("key xx "), strlen(cmd_shadow) - strlen("key xx "));
-		hotkey_strings[fn_number - 1][strlen(cmd_shadow) - strlen("key xx ")] = '\0';
+	if (mos_strtok_ptr[0] == '\"' && mos_strtok_ptr[strlen(mos_strtok_ptr) - 1] == '\"') {
+		mos_strtok_ptr[strlen(mos_strtok_ptr) - 1] = '\0';
+		mos_strtok_ptr++;		
 	}
+
+	if (hotkey_strings[fn_number - 1] != NULL) free(hotkey_strings[fn_number - 1]);
+
+	hotkey_strings[fn_number - 1] = malloc((strlen(mos_strtok_ptr) + 1) * sizeof(char));
+	strncpy(hotkey_strings[fn_number - 1], mos_strtok_ptr, strlen(mos_strtok_ptr));
+	hotkey_strings[fn_number - 1][strlen(mos_strtok_ptr)] = '\0';
 
 	return 0;
 }

--- a/src/mos.c
+++ b/src/mos.c
@@ -668,16 +668,59 @@ int mos_cmdSET(char * ptr) {
 // Returns:
 // - MOS error code
 //
-int	mos_cmdVDU(char *ptr) {
-	UINT24 	value;
-	
-	while(mos_parseNumber(NULL, &value)) {
-		if(value > 255) {
-			return 19;	// Bad Parameter
-		}
-		putch(value);
-	}
-	return 0;
+int mos_cmdVDU(char *ptr) {
+    char *value_str;
+    UINT24 value = 0;
+    
+    while (mos_parseString(NULL, &value_str)) {
+        UINT8 is_word = 0;
+        UINT8 base = 10;
+        char *endPtr;
+        size_t len = strlen(value_str);
+
+        //Strip semicolon notation and set as word
+        if (len > 0 && value_str[len - 1] == ';') {
+            value_str[len - 1] = '\0';
+            len--;
+            is_word = 1;
+        }
+
+        // Check for '0x' or '0X' prefix
+        if (len > 2 && (value_str[0] == '0' && tolower(value_str[1] == 'x'))) {
+            base = 16;
+        }
+		
+        // Check for '&' prefix
+        if (value_str[0] == '&') {
+            base = 16;
+            value_str++;
+            len--;
+        }
+        // Check for 'h' suffix
+        if (len > 0 && tolower(value_str[len - 1]) == 'h') {
+            value_str[len - 1] = '\0';
+            base = 16;
+        }
+
+        value = strtol(value_str, &endPtr, base);
+
+        if (*endPtr != '\0' || value > 65535) {
+            return 19;
+        }
+		
+        if (value > 255) {
+            is_word = 1;
+        }
+
+        if (is_word) {
+            putch(value & 0xFF); // write LSB
+            putch(value >> 8);   // write MSB
+        } else {
+            putch(value);
+        }
+    }
+
+    return 0;
 }
 
 // TIME

--- a/src/mos.c
+++ b/src/mos.c
@@ -75,35 +75,35 @@ extern volatile BYTE history_no;
 t_mosFileObject	mosFileObjects[MOS_maxOpenFiles];
 
 // Array of MOS commands and pointer to the C function to run
+// NB this list is iterated over, so the order is important
+// both for abbreviations and for the help command
 //
 static t_mosCommand mosCommands[] = {
-	{ ".", 			&mos_cmdDIR,		HELP_CAT_ARGS,		HELP_CAT,		HELP_DOT_ALIASES },
-	{ "DIR",		&mos_cmdDIR,		HELP_CAT_ARGS,		HELP_CAT,		HELP_DIR_ALIASES },
-	{ "LS",			&mos_cmdDIR,		HELP_CAT_ARGS,		HELP_CAT,		HELP_DIR_ALIASES },
-
-
-	{ "CAT",		&mos_cmdDIR,		HELP_CAT_ARGS,		HELP_CAT,		HELP_CAT_ALIASES },
-	{ "LOAD",		&mos_cmdLOAD,		HELP_LOAD_ARGS,		HELP_LOAD,		NULL },
-	{ "SAVE", 		&mos_cmdSAVE,		HELP_SAVE_ARGS,		HELP_SAVE,		NULL },
-	{ "DELETE",		&mos_cmdDEL,		HELP_DELETE_ARGS,	HELP_DELETE,	HELP_DELETE_ALIASES },
-	{ "ERASE",		&mos_cmdDEL,		HELP_DELETE_ARGS,	HELP_DELETE,	HELP_ERASE_ALIASES },
-	{ "JMP",		&mos_cmdJMP,		HELP_JMP_ARGS,		HELP_JMP,		NULL },
-	{ "RUN", 		&mos_cmdRUN,		HELP_RUN_ARGS,		HELP_RUN,		NULL },
-	{ "CD", 		&mos_cmdCD,			HELP_CD_ARGS,		HELP_CD,		NULL },
-	{ "RENAME",		&mos_cmdREN,		HELP_RENAME_ARGS,	HELP_RENAME,	HELP_RENAME_ALIASES },
-	{ "MOVE",		&mos_cmdREN,		HELP_RENAME_ARGS,	HELP_RENAME,	HELP_MOVE_ALIASES },
-	{ "MKDIR", 		&mos_cmdMKDIR,		HELP_MKDIR_ARGS,	HELP_MKDIR,	NULL },
-	{ "COPY", 		&mos_cmdCOPY,		HELP_COPY_ARGS,		HELP_COPY,	NULL },
-	{ "SET",		&mos_cmdSET,		HELP_SET_ARGS,		HELP_SET,	NULL },
-	{ "VDU",		&mos_cmdVDU,		HELP_VDU_ARGS,		HELP_VDU,	NULL },
-	{ "TIME", 		&mos_cmdTIME,		HELP_TIME_ARGS,		HELP_TIME,	NULL },
-	{ "CREDITS",	&mos_cmdCREDITS,	NULL,			HELP_CREDITS,	NULL },
-	{ "EXEC",		&mos_cmdEXEC,		HELP_EXEC_ARGS,		HELP_EXEC,	NULL },
-	{ "TYPE",		&mos_cmdTYPE,		HELP_TYPE_ARGS,		HELP_TYPE,	NULL },
-	{ "CLS",		&mos_cmdCLS,		NULL,			HELP_CLS,	NULL },
-	{ "MOUNT",		&mos_cmdMOUNT,		NULL,			HELP_MOUNT,	NULL },
-	{ "HELP",		&mos_cmdHELP,		HELP_HELP_ARGS,		HELP_HELP,	NULL },
-    { "KEY",		&mos_cmdKEY,		HELP_KEY_ARGS,		HELP_KEY,		NULL },
+	{ ".", 			&mos_cmdDIR,		HELP_CAT_ARGS,		HELP_CAT },
+	{ "CAT",		&mos_cmdDIR,		HELP_CAT_ARGS,		HELP_CAT },
+	{ "CD", 		&mos_cmdCD,			HELP_CD_ARGS,		HELP_CD },
+	{ "CLS",		&mos_cmdCLS,		NULL,			HELP_CLS },
+	{ "COPY", 		&mos_cmdCOPY,		HELP_COPY_ARGS,		HELP_COPY },
+	{ "CREDITS",	&mos_cmdCREDITS,	NULL,			HELP_CREDITS },
+	{ "DELETE",		&mos_cmdDEL,		HELP_DELETE_ARGS,	HELP_DELETE },
+	{ "DIR",		&mos_cmdDIR,		HELP_CAT_ARGS,		HELP_CAT },
+	{ "ERASE",		&mos_cmdDEL,		HELP_DELETE_ARGS,	HELP_DELETE },
+	{ "EXEC",		&mos_cmdEXEC,		HELP_EXEC_ARGS,		HELP_EXEC },
+	{ "HELP",		&mos_cmdHELP,		HELP_HELP_ARGS,		HELP_HELP },
+	{ "LOAD",		&mos_cmdLOAD,		HELP_LOAD_ARGS,		HELP_LOAD },
+	{ "LS",			&mos_cmdDIR,		HELP_CAT_ARGS,		HELP_CAT },
+	{ "JMP",		&mos_cmdJMP,		HELP_JMP_ARGS,		HELP_JMP },
+    { "KEY",		&mos_cmdKEY,		HELP_KEY_ARGS,		HELP_KEY },
+	{ "MKDIR", 		&mos_cmdMKDIR,		HELP_MKDIR_ARGS,	HELP_MKDIR },
+	{ "MOUNT",		&mos_cmdMOUNT,		NULL,			HELP_MOUNT },
+	{ "MOVE",		&mos_cmdREN,		HELP_RENAME_ARGS,	HELP_RENAME },
+	{ "RENAME",		&mos_cmdREN,		HELP_RENAME_ARGS,	HELP_RENAME },
+	{ "RUN", 		&mos_cmdRUN,		HELP_RUN_ARGS,		HELP_RUN },
+	{ "SAVE", 		&mos_cmdSAVE,		HELP_SAVE_ARGS,		HELP_SAVE },
+	{ "SET",		&mos_cmdSET,		HELP_SET_ARGS,		HELP_SET },
+	{ "TIME", 		&mos_cmdTIME,		HELP_TIME_ARGS,		HELP_TIME },
+	{ "TYPE",		&mos_cmdTYPE,		HELP_TYPE_ARGS,		HELP_TYPE },
+	{ "VDU",		&mos_cmdVDU,		HELP_VDU_ARGS,		HELP_VDU },
 };
 
 #define mosCommands_count (sizeof(mosCommands)/sizeof(t_mosCommand))
@@ -963,14 +963,41 @@ int	mos_cmdMOUNT(char *ptr) {
 	return 0;
 }
 
-void printCommandInfo(t_mosCommand * cmd) {
+void printCommandInfo(t_mosCommand * cmd, BOOL full) {
+	int aliases = 0;
+	int i;
+
 	printf("%s", cmd->name);
 	if (cmd->args != NULL)
 		printf(" %s", cmd->args);
-	if (cmd->aliases != NULL)
-		printf(" (Aliases: %s)", cmd->aliases);
+	
+	// find aliases
+	for (i = 0; i < mosCommands_count; ++i) {
+		if (mosCommands[i].func == cmd->func && mosCommands[i].name != cmd->name) {
+			aliases++;
+		}
+	}
+	if (aliases > 0) {
+		// print the aliases
+		printf(" (Aliases: ");
+		for (i = 0; i < mosCommands_count; ++i) {
+			if (mosCommands[i].func == cmd->func && mosCommands[i].name != cmd->name) {
+				printf("%s", mosCommands[i].name);
+				if (aliases == 2) {
+					printf(" and ");
+				} else if (aliases > 1) {
+					printf(", ");
+				}
+				aliases--;
+			}
+		}
+		printf(")");
+	}
+
 	printf("\r\n");
-	printf("%s\r\n", cmd->help);
+	if (full) {
+		printf("%s\r\n", cmd->help);
+	}
 }
 
 // HELP
@@ -978,30 +1005,50 @@ void printCommandInfo(t_mosCommand * cmd) {
 // - ptr: Pointer to the argument string in the line edit buffer
 // Returns:
 // -  0: Success
-//   20: Failure
 //
 int mos_cmdHELP(char *ptr) {
 	int i;
 	int found = 0;
 	char *cmd;
 
-	mos_parseString(NULL, &cmd);
-	if (cmd != NULL && strcasecmp(cmd, "all") == 0)
-		cmd = NULL;
+	BOOL hasCmd = mos_parseString(NULL, &cmd);
+	if (!hasCmd) {
+		cmd = "help";
+	}
 
-	for (i = 0; i < sizeof(mosCommands) / sizeof(mosCommands[0]); ++i) {
-		if (cmd == NULL) 
-			printCommandInfo(&mosCommands[i]);
-		else
-			if (strcasecmp(cmd, mosCommands[i].name) == 0) {
-				printCommandInfo(&mosCommands[i]);
-				found = 1;
+	for (i = 0; i < mosCommands_count; ++i) {
+		if (strcasecmp(cmd, mosCommands[i].name) == 0) {
+			printCommandInfo(&mosCommands[i], TRUE);
+			if (!hasCmd) {
+				// must be showing "help" command with no args, so show list of all commands
+				int col = 0;
+				int maxCol = scrcols;
+				printf("List of commands:\r\n");
+				for (i = 1; i < mosCommands_count; ++i) {
+					if (col + strlen(mosCommands[i].name) + 2 > maxCol) {
+						printf("\r\n");
+						col = 0;
+					}
+					printf("%s", mosCommands[i].name);
+					if (i < mosCommands_count - 1) {
+						printf(", ");
+					}
+					col += strlen(mosCommands[i].name) + 2;
+				}
+				printf("\r\n");
 			}
+			return 0;
+		}
 	}
 
-	if (cmd != NULL && !found) {
-		return FR_MOS_INVALID_COMMAND;
+	if (hasCmd && strcasecmp(cmd, "all") == 0) {
+		for (i = 0; i < mosCommands_count; ++i) {
+			printCommandInfo(&mosCommands[i], FALSE);
+		}
+		return 0;
 	}
+
+	printf("Command not found: %s\r\n", cmd);
 	return 0;
 }
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -65,6 +65,7 @@ extern volatile	BYTE vpd_protocol_flags;		// In globals.asm
 extern BYTE 	rtc;							// In globals.asm
 
 static FATFS	fs;					// Handle for the file system
+TCHAR cwd[256];						// Hold current working directory.
 static char * 	mos_strtok_ptr;		// Pointer for current position in string tokeniser
 
 TCHAR cwd[256];						// Hold current working directory.
@@ -280,6 +281,35 @@ char * mos_strtok_r(char *s1, const char *s2, char **ptr) {
 	*ptr = end + 1;
 	
 	return s1;
+}
+
+//Alternative to missing strnlen() in ZDS libraries
+size_t mos_strnlen(const char *s, size_t maxlen) {
+    size_t len = 0;
+    while (len < maxlen && s[len] != '\0') {
+        len++;
+    }
+    return len;
+}
+
+//Alternative to missing strdup() in ZDS libraries
+char *mos_strdup(const char *s) {
+    char *d = malloc(strlen(s) + 1);  // Allocate memory
+    if (d != NULL) strcpy(d, s);      // Copy the string
+    return d;
+}
+
+//Alternative to missing strndup() in ZDS libraries
+char *mos_strndup(const char *s, size_t n) {
+    size_t len = mos_strnlen(s, n);
+    char *d = malloc(len + 1);  // Allocate memory for length plus null terminator
+
+    if (d != NULL) {
+        strncpy(d, s, len);  // Copy up to len characters
+        d[len] = '\0';       // Null-terminate the string
+    }
+
+    return d;
 }
 
 // Parse a number from the line edit buffer
@@ -1013,44 +1043,102 @@ UINT24	mos_CD(char *path) {
 // Returns:
 // - FatFS return code
 // 
-UINT24	mos_DIR(char * path) {
-	FRESULT	fr;
-	DIR	  	dir;
-	static 	FILINFO  fno;
-	int		yr, mo, da, hr, mi;
-	char 	str[12];
-	
-	fr = f_getlabel("", str, 0);
-	if(fr != 0) {
-		return fr;
-	}	
-	printf("Volume: ");
-	if(strlen(str) > 0) {
-		printf("%s", str);
-	}
-	else {
-		printf("<No Volume Label>");
-	}
-	printf("\n\r\n\r");
-	
-	fr = f_opendir(&dir, path);
-	if(fr == FR_OK) {
-		for(;;) {
-			fr = f_readdir(&dir, &fno);
-			if (fr != FR_OK || fno.fname[0] == 0) {
-				break;  // Break on error or end of dir
-			}
-			yr = (fno.fdate & 0xFE00) >>  9;	// Bits 15 to  9, from 1980
-			mo = (fno.fdate & 0x01E0) >>  5;	// Bits  8 to  5
-			da = (fno.fdate & 0x001F);			// Bits  4 to  0
-			hr = (fno.ftime & 0xF800) >> 11;	// Bits 15 to 11
-			mi = (fno.ftime & 0x07E0) >>  5;	// Bits 10 to  5
-			
-			printf("%04d/%02d/%02d\t%02d:%02d %c %*lu %s\n\r", yr + 1980, mo, da, hr, mi, fno.fattrib & AM_DIR ? 'D' : ' ', 8, fno.fsize, fno.fname);
+UINT24 mos_DIR(char * inputPath) {
+    FRESULT fr;
+    DIR dir;
+    static FILINFO fno;
+    //char dirPath[256], pattern[32] = {0};
+	char *dirPath = NULL, *pattern = NULL;
+    BOOL usePattern = FALSE;
+    char str[12]; // Buffer for volume label
+    int yr, mo, da, hr, mi;
+
+    fr = f_getlabel("", str, 0);
+    if (fr != 0) {
+        return fr;
+    }
+
+    if (strchr(inputPath, '/') == NULL && strchr(inputPath, '*') != NULL) {
+        dirPath = mos_strdup(".");
+		if (!dirPath) goto cleanup;
+		pattern = mos_strdup(inputPath);
+		if (!pattern) goto cleanup;
+        usePattern = TRUE;
+    } else if (strcmp(inputPath, ".") == 0) {
+        dirPath = mos_strdup(".");
+		if (!dirPath) goto cleanup;
+	} else if (inputPath[0] == '/' && strchr(inputPath + 1, '/') == NULL) {
+		dirPath = mos_strdup("/");
+		if (strchr(inputPath + 1, '*') != NULL) {
+			pattern = mos_strdup(inputPath + 1);
+			if (!pattern) goto cleanup;
+			usePattern = TRUE;		
 		}
-	}
-	f_closedir(&dir);
-	return fr;
+    } else {
+        char *lastSeparator = strrchr(inputPath, '/');
+        if (lastSeparator != NULL && *(lastSeparator + 1) != '\0') {
+			dirPath = mos_strndup(inputPath, lastSeparator - inputPath + 1);
+			if (!dirPath) goto cleanup;
+            dirPath[lastSeparator - inputPath + 1] = '\0';
+            pattern = mos_strdup(lastSeparator + 1);
+			if (!pattern) goto cleanup;
+            usePattern = TRUE;
+        } else {
+			dirPath = mos_strdup(inputPath);
+			if (!dirPath) goto cleanup;
+        }
+    }
+	
+    fr = f_opendir(&dir, dirPath);
+	
+    if (fr == FR_OK) {
+		
+    printf("Volume: ");
+    if (strlen(str) > 0) {
+        printf("%s", str);
+    } else {
+        printf("<No Volume Label>");
+    }
+    printf("\n\r");		
+		
+	if (strcmp(dirPath, ".") == 0) {
+		f_getcwd(cwd, sizeof(cwd));
+		printf("Directory: %s\r\n\r\n", cwd);
+	} else printf("Directory: %s\r\n\r\n", dirPath);
+		
+        if (usePattern) {
+            fr = f_findfirst(&dir, &fno, dirPath, pattern);
+        } else {
+            fr = f_readdir(&dir, &fno);
+        }
+
+        while (fr == FR_OK && fno.fname[0]) {
+
+            yr = (fno.fdate & 0xFE00) >> 9;  // Bits 15 to  9, from 1980
+            mo = (fno.fdate & 0x01E0) >> 5;  // Bits  8 to  5
+            da = (fno.fdate & 0x001F);       // Bits  4 to  0
+            hr = (fno.ftime & 0xF800) >> 11; // Bits 15 to 11
+            mi = (fno.ftime & 0x07E0) >> 5;  // Bits 10 to  5
+
+            printf("%04d/%02d/%02d\t%02d:%02d %c %*lu %s\n\r", yr + 1980, mo, da, hr, mi, fno.fattrib & AM_DIR ? 'D' : ' ', 8, fno.fsize, fno.fname);
+
+            if (usePattern) {
+                fr = f_findnext(&dir, &fno);
+            } else {
+                fr = f_readdir(&dir, &fno);
+            }
+
+            if (!usePattern && fno.fname[0] == 0) break;
+        }
+		
+		printf("\r\n");
+    }
+
+	cleanup:
+		if (pattern) free(pattern);
+		if (dirPath) free(dirPath);
+		f_closedir(&dir);
+		return fr;
 }
 
 // Delete file
@@ -1060,10 +1148,79 @@ UINT24	mos_DIR(char * path) {
 // - FatFS return code
 // 
 UINT24 mos_DEL(char * filename) {
-	FRESULT	fr;	
-	
-	fr = f_unlink(filename);
-	return fr;
+    FRESULT fr = FR_INT_ERR;
+    DIR dir;
+    static FILINFO fno;
+    char *dirPath = NULL;
+    char *pattern = NULL;
+    BOOL usePattern = FALSE;
+
+    char *lastSeparator = strrchr(filename, '/');
+
+    if (strchr(filename, '*') != NULL) {
+        usePattern = TRUE;
+        if (filename[0] == '/' && strchr(filename + 1, '/') == NULL) {
+			dirPath = mos_strdup("/");
+			if (strchr(filename + 1, '*') != NULL) {
+				pattern = mos_strdup(filename + 1);
+				if (!pattern) goto cleanup;
+			}
+		
+		} else if (lastSeparator != NULL) {
+            dirPath = mos_strndup(filename, lastSeparator - filename);
+            if (!dirPath) return FR_INT_ERR;
+
+            pattern = mos_strdup(lastSeparator + 1);
+            if (!pattern) {
+                free(dirPath);
+                return FR_INT_ERR;
+            }
+        } else {
+            dirPath = mos_strdup(".");
+            pattern = mos_strdup(filename);
+            if (!dirPath || !pattern) {
+                free(dirPath);
+                free(pattern);
+                return FR_INT_ERR;
+            }
+        }
+    } else {
+        dirPath = mos_strdup(filename);
+        if (!dirPath) return FR_INT_ERR;
+    }	
+
+    if (usePattern) {
+        fr = f_opendir(&dir, dirPath);
+        if (fr != FR_OK) goto cleanup;
+
+        fr = f_findfirst(&dir, &fno, dirPath, pattern);
+        while (fr == FR_OK && fno.fname[0] != '\0') {
+            size_t fullPathLen = strlen(dirPath) + strlen(fno.fname) + 2;
+            char *fullPath = malloc(fullPathLen);
+            if (!fullPath) {
+                fr = FR_INT_ERR;
+                break;
+            }
+
+            sprintf(fullPath, "%s/%s", dirPath, fno.fname);  // Construct full path
+            printf("Deleting %s\r\n", fullPath);
+			fr = f_unlink(fullPath);
+            free(fullPath);
+
+            if (fr != FR_OK) break;
+            fr = f_findnext(&dir, &fno);
+        }
+
+        f_closedir(&dir);
+		printf("\r\n");
+    } else {
+        fr = f_unlink(filename);
+    }
+
+	cleanup:
+		free(dirPath);
+		free(pattern);
+		return fr;
 }
 
 // Rename file
@@ -1073,11 +1230,95 @@ UINT24 mos_DEL(char * filename) {
 // Returns:
 // - FatFS return code
 // 
-UINT24 mos_REN(char * filename1, char * filename2) {
-	FRESULT fr;
-	
-	fr = f_rename(filename1, filename2);
-	return fr;
+UINT24 mos_REN(char *srcPath, char *dstPath) {
+    FRESULT fr;
+    DIR dir;
+    static FILINFO fno;
+    char *srcDir = NULL, *pattern = NULL, *fullSrcPath = NULL, *fullDstPath = NULL, *srcFilename = NULL;
+	char *asteriskPos, *lastSeparator;
+    BOOL usePattern = FALSE;
+
+    if (strchr(dstPath, '*') != NULL) {
+        printf("Wildcards permitted in source only.\r\n");
+        return FR_INVALID_PARAMETER;
+    }
+
+    asteriskPos = strchr(srcPath, '*');
+    lastSeparator = asteriskPos ? strrchr(srcPath, '/') : NULL;
+
+    if (asteriskPos != NULL) {
+        if (lastSeparator != NULL) {
+            srcDir = mos_strndup(srcPath, lastSeparator - srcPath + 1); // Include '/'
+            pattern = mos_strdup(asteriskPos);
+        } else {
+            srcDir = mos_strdup(""); // Empty string for later use as a destination path
+            pattern = mos_strdup(srcPath);
+        }
+        if (!srcDir || !pattern) {
+            fr = FR_INT_ERR; // Out of memory
+            goto cleanup;
+        }
+        usePattern = TRUE;
+    } else {
+        srcDir = mos_strdup(srcPath);
+        if (!srcDir) return FR_INT_ERR; // Out of memory
+        usePattern = FALSE;
+    }
+
+    if (usePattern) {
+        fr = f_opendir(&dir, srcDir);
+        if (fr != FR_OK) goto cleanup;
+
+        fr = f_findfirst(&dir, &fno, srcDir, pattern);
+        while (fr == FR_OK && fno.fname[0] != '\0') {
+            size_t srcPathLen = strlen(srcDir) + strlen(fno.fname) + 1;
+            size_t dstPathLen = strlen(dstPath) + strlen(fno.fname) + 2; // +2 for '/' and null terminator
+			fullSrcPath = malloc(srcPathLen);
+            fullDstPath = malloc(dstPathLen);
+
+            if (!fullSrcPath || !fullDstPath) {
+                fr = FR_INT_ERR; // Out of memory
+                free(fullSrcPath);
+                free(fullDstPath);
+                break;
+            }
+
+            sprintf(fullSrcPath, "%s%s", srcDir, fno.fname);
+            sprintf(fullDstPath, "%s%s%s", dstPath, (dstPath[strlen(dstPath) - 1] == '/' ? "" : "/"), fno.fname);
+
+            printf("Moving %s to %s\r\n", fullSrcPath, fullDstPath);
+			fr = f_rename(fullSrcPath, fullDstPath);
+            free(fullSrcPath);
+            free(fullDstPath);
+            fullSrcPath = NULL;
+            fullDstPath = NULL;
+
+            if (fr != FR_OK) break;
+            fr = f_findnext(&dir, &fno);
+        }
+
+        f_closedir(&dir);
+		
+    } else {
+		
+        size_t fullDstPathLen = strlen(dstPath) + strlen(srcPath) + 2; // +2 for potential '/' and null terminator
+        fullDstPath = malloc(fullDstPathLen);
+        if (!fullDstPath) return FR_INT_ERR;
+
+        srcFilename = strrchr(srcPath, '/');
+        srcFilename = (srcFilename != NULL) ? srcFilename + 1 : srcPath;
+        sprintf(fullDstPath, "%s%s%s", dstPath, (dstPath[strlen(dstPath) - 1] == '/' ? "" : "/"), srcFilename);
+
+        fr = f_rename(srcPath, fullDstPath);
+		
+        free(fullDstPath);
+    }
+	printf("\r\n");
+
+cleanup:
+    free(srcDir);
+    free(pattern);
+    return fr;
 }
 
 // Copy file
@@ -1087,36 +1328,131 @@ UINT24 mos_REN(char * filename1, char * filename2) {
 // Returns:
 // - FatFS return code
 // 
-UINT24 mos_COPY(char * filename1, char * filename2) {
-	FRESULT fr;
-	FIL		fsrc, fdst;
-	BYTE	buffer[1024];
-	UINT	br, bw;
+UINT24 mos_COPY(char *srcPath, char *dstPath) {
+    FRESULT fr;
+    FIL fsrc, fdst;
+    DIR dir;
+    static FILINFO fno;
+    BYTE buffer[1024];
+    UINT br, bw;
+    char *srcDir = NULL, *pattern = NULL, *fullSrcPath = NULL, *fullDstPath = NULL, *srcFilename = NULL;
+	char *asteriskPos, *lastSeparator;
+    BOOL usePattern = FALSE;
 
-	// Open the file to copy
-	//
-	fr = f_open(&fsrc, filename1, FA_READ);
-	if(fr) {
-		return fr;
-	}
-	// Open the destination file
-	//
-	fr = f_open(&fdst, filename2, FA_WRITE | FA_CREATE_NEW);
-	if(fr) {
-		return fr;
-	}
-	// Copy the file
-	//
-	while(1) {
-        fr = f_read(&fsrc, buffer, sizeof buffer, &br);	// Read a chunk of data from the source file
-        if (br == 0) break;								// Error or EOF
-        fr = f_write(&fdst, buffer, br, &bw);			// Write it to the destination file
-        if (bw < br) break; 							// Error or Disk Full
-	}
-    f_close(&fsrc);										// Close both files
-    f_close(&fdst);
+    if (strchr(dstPath, '*') != NULL) {
+        return FR_INVALID_PARAMETER; // Wildcards not allowed in destination path
+    }
 
-	return fr;
+    asteriskPos = strchr(srcPath, '*');
+    lastSeparator = asteriskPos ? strrchr(srcPath, '/') : NULL;
+
+    if (asteriskPos != NULL) {
+        usePattern = TRUE;
+        if (lastSeparator != NULL) {
+            srcDir = mos_strndup(srcPath, lastSeparator - srcPath + 1); // Include '/'
+            pattern = mos_strdup(asteriskPos);
+        } else {
+            srcDir = mos_strdup("");
+            pattern = mos_strdup(srcPath);
+        }
+        if (!srcDir || !pattern) {
+            fr = FR_INT_ERR;
+            goto cleanup;
+        }
+    } else {
+        srcDir = mos_strdup(srcPath);
+        if (!srcDir) return FR_INT_ERR;
+    }
+
+    if (usePattern) {
+        fr = f_opendir(&dir, srcDir);
+        if (fr != FR_OK) goto cleanup;
+
+        fr = f_findfirst(&dir, &fno, srcDir, pattern);
+        while (fr == FR_OK && fno.fname[0] != '\0') {
+            size_t srcPathLen = strlen(srcDir) + strlen(fno.fname) + 1;
+            size_t dstPathLen = strlen(dstPath) + strlen(fno.fname) + 2; // +2 for '/' and null terminator
+            fullSrcPath = malloc(srcPathLen);
+            fullDstPath = malloc(dstPathLen);
+
+            if (!fullSrcPath || !fullDstPath) {
+                fr = FR_INT_ERR;
+                goto file_cleanup;
+            }
+
+            sprintf(fullSrcPath, "%s%s", srcDir, fno.fname);
+            sprintf(fullDstPath, "%s%s%s", dstPath, (dstPath[strlen(dstPath) - 1] == '/' ? "" : "/"), fno.fname);
+
+            fr = f_open(&fsrc, fullSrcPath, FA_READ);
+            if (fr != FR_OK) goto file_cleanup;
+            fr = f_open(&fdst, fullDstPath, FA_WRITE | FA_CREATE_NEW);
+            if (fr != FR_OK) {
+                f_close(&fsrc);
+                goto file_cleanup;
+            }
+
+			printf("Copying %s to %s\r\n", fullSrcPath, fullDstPath);
+            while (1) {
+                fr = f_read(&fsrc, buffer, sizeof(buffer), &br);
+                if (br == 0 || fr != FR_OK) break;
+                fr = f_write(&fdst, buffer, br, &bw);
+                if (bw < br || fr != FR_OK) break;
+            }
+
+            f_close(&fsrc);
+            f_close(&fdst);
+
+        file_cleanup:
+            free(fullSrcPath);
+            free(fullDstPath);
+            fullSrcPath = NULL;
+            fullDstPath = NULL;
+
+            if (fr != FR_OK) break;
+            fr = f_findnext(&dir, &fno);
+        }
+
+        f_closedir(&dir);
+    } else {
+        size_t fullDstPathLen = strlen(dstPath) + strlen(srcPath) + 2; // +2 for potential '/' and null terminator
+        fullDstPath = malloc(fullDstPathLen);
+        if (!fullDstPath) return FR_INT_ERR;
+        srcFilename = strrchr(srcPath, '/');
+        srcFilename = (srcFilename != NULL) ? srcFilename + 1 : srcPath;
+        sprintf(fullDstPath, "%s%s%s", dstPath, (dstPath[strlen(dstPath) - 1] == '/' ? "" : "/"), srcFilename);
+
+        fr = f_open(&fsrc, srcPath, FA_READ);
+        if (fr != FR_OK) {
+            free(fullDstPath);
+            return fr;
+        }
+        fr = f_open(&fdst, fullDstPath, FA_WRITE | FA_CREATE_NEW);
+        if (fr != FR_OK) {
+            f_close(&fsrc);
+            free(fullDstPath);
+            return fr;
+        }
+
+		printf("Moving %s to %s\r\n", fullSrcPath, fullDstPath);
+        while (1) {
+            fr = f_read(&fsrc, buffer, sizeof(buffer), &br);
+            if (br == 0 || fr != FR_OK) break;
+            fr = f_write(&fdst, buffer, br, &bw);
+            if (bw < br || fr != FR_OK) break;
+        }
+
+        f_close(&fsrc);
+        f_close(&fdst);
+        free(fullDstPath);
+    }
+	printf("\r\n");
+
+cleanup:
+    free(srcDir);
+    free(pattern);
+    free(fullSrcPath);
+    free(fullDstPath);
+    return fr;
 }
 
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -136,6 +136,7 @@ static char * mos_errors[] = {
 	"Invalid command",
 	"Invalid executable",
 	"Out of memory",
+	"Not implemented",
 };
 
 #define mos_errors_count (sizeof(mos_errors)/sizeof(char *))

--- a/src/mos.c
+++ b/src/mos.c
@@ -438,30 +438,9 @@ int mos_cmdKEY(char *ptr) {
 		
 		printf("Hotkey assignments:\r\n\r\n");
 		
-		if (hotkey_strings[0] != NULL) printf("F1:  %s\r\n", hotkey_strings[0]);
-			else printf("F1:  N/A\r\n");
-		if (hotkey_strings[1] != NULL) printf("F2:  %s\r\n", hotkey_strings[1]);
-			else printf("F2:  N/A\r\n");
-		if (hotkey_strings[2] != NULL) printf("F3:  %s\r\n", hotkey_strings[2]);
-			else printf("F3:  N/A\r\n");
-		if (hotkey_strings[3] != NULL) printf("F4:  %s\r\n", hotkey_strings[3]);
-			else printf("F4:  N/A\r\n");
-		if (hotkey_strings[4] != NULL) printf("F5:  %s\r\n", hotkey_strings[4]);
-			else printf("F5:  N/A\r\n");
-		if (hotkey_strings[5] != NULL) printf("F6:  %s\r\n", hotkey_strings[5]);
-			else printf("F6:  N/A\r\n");
-		if (hotkey_strings[6] != NULL) printf("F7:  %s\r\n", hotkey_strings[6]);
-			else printf("F7:  N/A\r\n");
-		if (hotkey_strings[7] != NULL) printf("F8:  %s\r\n", hotkey_strings[7]);
-			else printf("F8:  N/A\r\n");
-		if (hotkey_strings[8] != NULL) printf("F9:  %s\r\n", hotkey_strings[8]);
-			else printf("F9:  N/A\r\n");
-		if (hotkey_strings[9] != NULL) printf("F10: %s\r\n", hotkey_strings[9]);
-			else printf("F10: N/A\r\n");
-		if (hotkey_strings[10] != NULL) printf("F11: %s\r\n", hotkey_strings[10]);
-			else printf("F11: N/A\r\n");
-		if (hotkey_strings[11] != NULL) printf("F12: %s\r\n", hotkey_strings[11]);
-			else printf("F12: N/A\r\n");
+		for (int key = 0; key < 12; key++) {
+				printf("F%d: %s\r\n", key+1, hotkey_strings[key] == NULL ? "N/A" : hotkey_strings[key]);
+		}
 				
 		printf("\r\n");
 		return 0;

--- a/src/mos.c
+++ b/src/mos.c
@@ -569,7 +569,7 @@ int mos_cmdLOAD(char * ptr) {
 	if(
 		!mos_parseString(NULL, &filename)
 	) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	}
 	if(!mos_parseNumber(NULL, &addr)) addr = MOS_defaultLoadAddress;
 	fr = mos_LOAD(filename, addr, 0);
@@ -592,7 +592,7 @@ int mos_cmdEXEC(char *ptr) {
 	if(
 		!mos_parseString(NULL, &filename)
 	) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	}
 	fr = mos_EXEC(filename, buf, sizeof buf);
 	return fr;
@@ -615,7 +615,7 @@ int mos_cmdSAVE(char * ptr) {
 		!mos_parseNumber(NULL, &addr) ||
 		!mos_parseNumber(NULL, &size)
 	) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	}
 	fr = mos_SAVE(filename, addr, size);
 	return fr;
@@ -635,7 +635,7 @@ int mos_cmdDEL(char * ptr) {
 	if(
 		!mos_parseString(NULL, &filename) 
 	) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	}
 	fr = mos_DEL(filename);
 	return fr;
@@ -651,7 +651,7 @@ int mos_cmdJMP(char *ptr) {
 	UINT24 	addr;
 	void (* dest)(void) = 0;
 	if(!mos_parseNumber(NULL, &addr)) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	};
 	dest = (void *)addr;
 	dest();
@@ -702,7 +702,7 @@ int mos_cmdCD(char * ptr) {
 	if(
 		!mos_parseString(NULL, &path) 
 	) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	}
 	fr = f_chdir(path);
 	f_getcwd(cwd, sizeof(cwd)); //Update full path.
@@ -724,7 +724,7 @@ int mos_cmdREN(char *ptr) {
 		!mos_parseString(NULL, &filename1) ||
 		!mos_parseString(NULL, &filename2)
 	) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	}
 	fr = mos_REN(filename1, filename2);
 	return fr;
@@ -745,7 +745,7 @@ int mos_cmdCOPY(char *ptr) {
 		!mos_parseString(NULL, &filename1) ||
 		!mos_parseString(NULL, &filename2)
 	) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	}
 	fr = mos_COPY(filename1, filename2);
 	return fr;
@@ -765,7 +765,7 @@ int mos_cmdMKDIR(char * ptr) {
 	if(
 		!mos_parseString(NULL, &filename) 
 	) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	}
 	fr = mos_MKDIR(filename);
 	return fr;
@@ -785,7 +785,7 @@ int mos_cmdSET(char * ptr) {
 		!mos_parseString(NULL, &command) ||
 		!mos_parseNumber(NULL, &value)
 	) {
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 	}
 	if(strcasecmp(command, "KEYBOARD") == 0) {
 		putch(23);
@@ -801,7 +801,7 @@ int mos_cmdSET(char * ptr) {
 		putch(value & 0xFF);
 		return 0;
 	}
-	return 19; // Bad Parameter
+	return FR_INVALID_PARAMETER;
 }
 
 // VDU <char1> <char2> ... <charN>
@@ -847,7 +847,7 @@ int mos_cmdVDU(char *ptr) {
         value = strtol(value_str, &endPtr, base);
 
         if (*endPtr != '\0' || value > 65535) {
-            return 19;
+            return FR_INVALID_PARAMETER;
         }
 		
         if (value > 255) {
@@ -888,7 +888,7 @@ int mos_cmdTIME(char *ptr) {
 			!mos_parseNumber(NULL, &mi) ||
 			!mos_parseNumber(NULL, &se) 
 		) {
-			return 19;
+			return FR_INVALID_PARAMETER;
 		}
 		buffer[0] = yr - EPOCH_YEAR;
 		buffer[1] = mo;
@@ -930,7 +930,7 @@ int mos_cmdTYPE(char * ptr) {
 	UINT24 	addr;
 
 	if(!mos_parseString(NULL, &filename))
-		return 19; // Bad Parameter
+		return FR_INVALID_PARAMETER;
 
 	fr = mos_TYPE(filename);
 	return fr;
@@ -1000,7 +1000,7 @@ int mos_cmdHELP(char *ptr) {
 	}
 
 	if (cmd != NULL && !found) {
-		return 20;
+		return FR_MOS_INVALID_COMMAND;
 	}
 	return 0;
 }

--- a/src/mos.c
+++ b/src/mos.c
@@ -67,6 +67,8 @@ extern BYTE 	rtc;							// In globals.asm
 static FATFS	fs;					// Handle for the file system
 static char * 	mos_strtok_ptr;		// Pointer for current position in string tokeniser
 
+TCHAR cwd[256];						// Hold current working directory.
+
 extern volatile BYTE history_no;
 
 t_mosFileObject	mosFileObjects[MOS_maxOpenFiles];
@@ -162,7 +164,7 @@ BYTE mos_getkey() {
 //
 UINT24 mos_input(char * buffer, int bufferLength) {
 	INT24 retval;
-	putch(MOS_prompt);
+	printf("%s%c", cwd, MOS_prompt);
 	retval = mos_EDITLINE(buffer, bufferLength, 1);
 	printf("\n\r");
 	return retval;
@@ -564,6 +566,7 @@ int mos_cmdCD(char * ptr) {
 		return 19; // Bad Parameter
 	}
 	fr = f_chdir(path);
+	f_getcwd(cwd, sizeof(cwd)); //Update full path.
 	return fr;
 }
 
@@ -817,6 +820,7 @@ int	mos_cmdMOUNT(char *ptr) {
 	fr = mos_mount();
 	if (fr != FR_OK)
 		mos_error(fr);
+	f_getcwd(cwd, sizeof(cwd)); //Update full path.
 	return 0;
 }
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -64,6 +64,8 @@ extern volatile	BYTE keyascii;					// In globals.asm
 extern volatile	BYTE vpd_protocol_flags;		// In globals.asm
 extern BYTE 	rtc;							// In globals.asm
 
+char	cmd_shadow[256];		// Will hold preserved edit line
+
 static FATFS	fs;					// Handle for the file system
 static char * 	mos_strtok_ptr;		// Pointer for current position in string tokeniser
 
@@ -99,6 +101,7 @@ static t_mosCommand mosCommands[] = {
 	{ "CLS",		&mos_cmdCLS,		NULL,			HELP_CLS,	NULL },
 	{ "MOUNT",		&mos_cmdMOUNT,		NULL,			HELP_MOUNT,	NULL },
 	{ "HELP",		&mos_cmdHELP,		HELP_HELP_ARGS,		HELP_HELP,	NULL },
+    { "KEY",		&mos_cmdKEY,		HELP_KEY_ARGS,		HELP_KEY,		NULL },
 };
 
 #define mosCommands_count (sizeof(mosCommands)/sizeof(t_mosCommand))
@@ -345,6 +348,9 @@ int mos_exec(char * buffer) {
 	if (ptr != NULL && *ptr == '#') {
 	    return fr;
 	}
+	
+	strcpy (cmd_shadow, ptr);
+	
 	ptr = mos_strtok(ptr, " ");
 	if(ptr != NULL) {
 		func = mos_getCommand(ptr);
@@ -414,6 +420,85 @@ int mos_cmdDIR(char * ptr) {
 		return mos_DIR(".");
 	}
 	return mos_DIR(path);
+}
+
+// KEY command
+// Parameters:
+// - ptr: Pointer to the argument string in the line edit buffer
+// Returns:
+// - MOS error code
+//
+int mos_cmdKEY(char *ptr) {
+
+	UINT24 fn_number = 0;
+	char *hotkey_string;
+	char *hotkey_string_token;
+
+	if (!mos_parseNumber(NULL, &fn_number)) {
+		
+		printf("Hotkey assignments:\r\n\r\n");
+		
+		if (hotkey_strings[0] != NULL) printf("F1:  %s\r\n", hotkey_strings[0]);
+			else printf("F1:  N/A\r\n");
+		if (hotkey_strings[1] != NULL) printf("F2:  %s\r\n", hotkey_strings[1]);
+			else printf("F2:  N/A\r\n");
+		if (hotkey_strings[2] != NULL) printf("F3:  %s\r\n", hotkey_strings[2]);
+			else printf("F3:  N/A\r\n");
+		if (hotkey_strings[3] != NULL) printf("F4:  %s\r\n", hotkey_strings[3]);
+			else printf("F4:  N/A\r\n");
+		if (hotkey_strings[4] != NULL) printf("F5:  %s\r\n", hotkey_strings[4]);
+			else printf("F5:  N/A\r\n");
+		if (hotkey_strings[5] != NULL) printf("F6:  %s\r\n", hotkey_strings[5]);
+			else printf("F6:  N/A\r\n");
+		if (hotkey_strings[6] != NULL) printf("F7:  %s\r\n", hotkey_strings[6]);
+			else printf("F7:  N/A\r\n");
+		if (hotkey_strings[7] != NULL) printf("F8:  %s\r\n", hotkey_strings[7]);
+			else printf("F8:  N/A\r\n");
+		if (hotkey_strings[8] != NULL) printf("F9:  %s\r\n", hotkey_strings[8]);
+			else printf("F9:  N/A\r\n");
+		if (hotkey_strings[9] != NULL) printf("F10: %s\r\n", hotkey_strings[9]);
+			else printf("F10: N/A\r\n");
+		if (hotkey_strings[10] != NULL) printf("F11: %s\r\n", hotkey_strings[10]);
+			else printf("F11: N/A\r\n");
+		if (hotkey_strings[11] != NULL) printf("F12: %s\r\n", hotkey_strings[11]);
+			else printf("F12: N/A\r\n");
+				
+		printf("\r\n");
+		return 0;
+			
+	}
+
+	if (fn_number < 1 || fn_number > 12) {
+		printf("Invalid FN-key number.\r\n");
+		return 0;
+	}
+
+	if (!mos_parseString(NULL, &hotkey_string)) {
+
+		if (hotkey_strings[fn_number - 1] != NULL) {
+			free(hotkey_strings[fn_number - 1]);
+			hotkey_strings[fn_number - 1] = NULL;
+			printf("F%u cleared.\r\n", fn_number);
+		} else printf("No string hotkey provided.\r\n");
+
+		return 0;
+
+	}
+
+	//"key x " = 6 chars
+	//"key xx " = 7 chars
+
+	if (fn_number < 10)	{
+		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key x ") + 1) * sizeof(char));
+		strncpy(hotkey_strings[fn_number - 1], cmd_shadow + strlen("key x "), strlen(cmd_shadow) - strlen("key x "));
+		hotkey_strings[fn_number - 1][strlen(cmd_shadow) - strlen("key x ")] = '\0';
+	} else {
+		hotkey_strings[fn_number - 1] = malloc((strlen(cmd_shadow) - strlen("key xx ") + 1) * sizeof(char));
+		strncpy(hotkey_strings[fn_number - 1], cmd_shadow + strlen("key xx "), strlen(cmd_shadow) - strlen("key xx "));
+		hotkey_strings[fn_number - 1][strlen(cmd_shadow) - strlen("key xx ")] = '\0';
+	}
+
+	return 0;
 }
 
 // LOAD <filename> <addr> command

--- a/src/mos.c
+++ b/src/mos.c
@@ -65,7 +65,6 @@ extern volatile	BYTE vpd_protocol_flags;		// In globals.asm
 extern BYTE 	rtc;							// In globals.asm
 
 static FATFS	fs;					// Handle for the file system
-TCHAR cwd[256];						// Hold current working directory.
 static char * 	mos_strtok_ptr;		// Pointer for current position in string tokeniser
 
 TCHAR cwd[256];						// Hold current working directory.

--- a/src/mos.c
+++ b/src/mos.c
@@ -365,7 +365,7 @@ BOOL mos_parseString(char * ptr, char ** p_Value) {
 // Returns:
 // - MOS error code
 //
-int mos_exec(char * buffer) {
+int mos_exec(char * buffer, BOOL in_mos) {
 	char * 	ptr;
 	int 	fr = 0;
 	int 	(*func)(char * ptr);
@@ -408,22 +408,44 @@ int mos_exec(char * buffer) {
 					return fr;
 				}
 
-				sprintf(path, "/bin/%s.bin", ptr);
-				fr = mos_LOAD(path, MOS_defaultLoadAddress, 0);
-				if(fr == 0) {
-					mode = mos_execMode((UINT8 *)MOS_defaultLoadAddress);
-					switch(mode) {
-						case 0:		// Z80 mode
-							fr = exec16(MOS_defaultLoadAddress, mos_strtok_ptr);
-							break;
-						case 1: 	// ADL mode
-							fr = exec24(MOS_defaultLoadAddress, mos_strtok_ptr);
-							break;	
-						default:	// Unrecognised header
-							fr = 21;
-							break;
+				if (in_mos) {
+				
+					sprintf(path, "%s.bin", ptr);
+					fr = mos_LOAD(path, MOS_defaultLoadAddress, 0);
+					if(fr == 0) {
+						mode = mos_execMode((UINT8 *)MOS_defaultLoadAddress);
+						switch(mode) {
+							case 0:		// Z80 mode
+								fr = exec16(MOS_defaultLoadAddress, mos_strtok_ptr);
+								break;
+							case 1: 	// ADL mode
+								fr = exec24(MOS_defaultLoadAddress, mos_strtok_ptr);
+								break;	
+							default:	// Unrecognised header
+								fr = 21;
+								break;
+						}
+						return fr;
+					}				
+					
+					sprintf(path, "/bin/%s.bin", ptr);
+					fr = mos_LOAD(path, MOS_defaultLoadAddress, 0);
+					if(fr == 0) {
+						mode = mos_execMode((UINT8 *)MOS_defaultLoadAddress);
+						switch(mode) {
+							case 0:		// Z80 mode
+								fr = exec16(MOS_defaultLoadAddress, mos_strtok_ptr);
+								break;
+							case 1: 	// ADL mode
+								fr = exec24(MOS_defaultLoadAddress, mos_strtok_ptr);
+								break;	
+							default:	// Unrecognised header
+								fr = 21;
+								break;
+						}
+						return fr;
 					}
-					return fr;
+
 				}				
 				else {
 					if(fr == 4) {
@@ -1511,7 +1533,7 @@ UINT24 mos_EXEC(char * filename, char * buffer, UINT24 size) {
 		while(!f_eof(&fil)) {
 			line++;
 			f_gets(buffer, size, &fil);
-			fr = mos_exec(buffer);
+			fr = mos_exec(buffer, TRUE);
 			if (fr != FR_OK) {
 				printf("\r\nError executing %s at line %d\r\n", filename, line);
 				break;
@@ -1701,7 +1723,7 @@ void mos_GETERROR(UINT8 errno, UINT24 address, UINT24 size) {
 //
 UINT24 mos_OSCLI(char * cmd) {
 	UINT24 fr;
-	fr = mos_exec(cmd);
+	fr = mos_exec(cmd, FALSE);
 	return fr;
 }
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -60,6 +60,7 @@ extern void *	set_vector(unsigned int vector, void(*handler)(void));	// In vecto
 extern int 		exec16(UINT24 addr, char * params);	// In misc.asm
 extern int 		exec24(UINT24 addr, char * params);	// In misc.asm
 
+extern BYTE scrcols, scrcolours;               // In globals.asm
 extern volatile	BYTE keyascii;					// In globals.asm
 extern volatile	BYTE vpd_protocol_flags;		// In globals.asm
 extern BYTE 	rtc;							// In globals.asm

--- a/src/mos.c
+++ b/src/mos.c
@@ -787,7 +787,7 @@ int mos_cmdSET(char * ptr) {
 	) {
 		return 19; // Bad Parameter
 	}
-	if(strcasecmp(command, "KEYBOARD") == 0 && value <= 15) {
+	if(strcasecmp(command, "KEYBOARD") == 0) {
 		putch(23);
 		putch(0);
 		putch(VDP_keycode);

--- a/src/mos.c
+++ b/src/mos.c
@@ -405,7 +405,26 @@ int mos_exec(char * buffer) {
 							fr = 21;
 							break;
 					}
+					return fr;
 				}
+
+				sprintf(path, "/bin/%s.bin", ptr);
+				fr = mos_LOAD(path, MOS_defaultLoadAddress, 0);
+				if(fr == 0) {
+					mode = mos_execMode((UINT8 *)MOS_defaultLoadAddress);
+					switch(mode) {
+						case 0:		// Z80 mode
+							fr = exec16(MOS_defaultLoadAddress, mos_strtok_ptr);
+							break;
+						case 1: 	// ADL mode
+							fr = exec24(MOS_defaultLoadAddress, mos_strtok_ptr);
+							break;	
+						default:	// Unrecognised header
+							fr = 21;
+							break;
+					}
+					return fr;
+				}				
 				else {
 					if(fr == 4) {
 						fr = 20;

--- a/src/mos.h
+++ b/src/mos.h
@@ -86,7 +86,7 @@ int		mos_cmdTYPE(char *ptr);
 int		mos_cmdCLS(char *ptr);
 int		mos_cmdMOUNT(char *ptr);
 int		mos_cmdHELP(char *ptr);
-int		mos_cmdKEY(char *ptr);
+int		mos_cmdHOTKEY(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
@@ -197,13 +197,13 @@ UINT8	fat_EOF(FIL * fp);
 #define HELP_TYPE			"Display the contents of a file on the screen\r\n"
 #define HELP_TYPE_ARGS		"<filename>"
 
-#define HELP_KEY			"Store a command in one of 12 hotkey slots assigned to F1-F12\r\n\r\n" \
+#define HELP_HOTKEY			"Store a command in one of 12 hotkey slots assigned to F1-F12\r\n\r\n" \
 							"Optionally, the command string can include \"%s\" as a marker\r\n" \
 							"in which case the hotkey command will be built either side.\r\n\r\n" \
-							"KEY without any arguments will list the currently assigned\r\n" \
+							"HOTKEY without any arguments will list the currently assigned\r\n" \
 							"command strings.\r\n"
 							
-#define HELP_KEY_ARGS		"<key number> <command string>"
+#define HELP_HOTKEY_ARGS	"<key number> <command string>"
 
 #define HELP_CLS			"Clear the screen\r\n"
 

--- a/src/mos.h
+++ b/src/mos.h
@@ -87,6 +87,7 @@ int		mos_cmdTYPE(char *ptr);
 int		mos_cmdCLS(char *ptr);
 int		mos_cmdMOUNT(char *ptr);
 int		mos_cmdHELP(char *ptr);
+int		mos_cmdVDU(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);

--- a/src/mos.h
+++ b/src/mos.h
@@ -60,7 +60,7 @@ BOOL 	mos_cmp(char *p1, char *p2);
 char *	mos_trim(char * s);
 char *	mos_strtok(char *s1, char * s2);
 char *	mos_strtok_r(char *s1, const char *s2, char **ptr);
-int		mos_exec(char * buffer);
+int		mos_exec(char * buffer, BOOL in_mos);
 UINT8 	mos_execMode(UINT8 * ptr);
 
 int		mos_mount(void);

--- a/src/mos.h
+++ b/src/mos.h
@@ -55,7 +55,7 @@ void 	mos_error(int error);
 
 BYTE	mos_getkey(void);
 UINT24	mos_input(char * buffer, int bufferLength);
-void *	mos_getCommand(char * ptr);
+t_mosCommand	*mos_getCommand(char * ptr);
 BOOL 	mos_cmp(char *p1, char *p2);
 char *	mos_trim(char * s);
 char *	mos_strtok(char *s1, char * s2);

--- a/src/mos.h
+++ b/src/mos.h
@@ -132,7 +132,7 @@ UINT8	fat_EOF(FIL * fp);
 							"third-party libraries used in the Agon firmware\r\n"
 
 #define HELP_DELETE			"Delete a file or folder (must be empty)\r\n"
-#define HELP_DELETE_ARGS	"<filename>"
+#define HELP_DELETE_ARGS	"[-f] <filename>"
 
 #define HELP_EXEC			"Run a batch file containing MOS commands\r\n"
 #define HELP_EXEC_ARGS		"<filename>"

--- a/src/mos.h
+++ b/src/mos.h
@@ -92,10 +92,13 @@ UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_TYPE(char * filename);
 UINT24	mos_CD(char * path);
+UINT24	mos_DIR_API(char * path);
 UINT24	mos_DIR(char * path, BOOL longListing);
 UINT24	mos_DEL(char * filename);
-UINT24 	mos_REN(char * filename1, char * filename2);
-UINT24	mos_COPY(char * filename1, char * filename2);
+UINT24	mos_REN_API(char *srcPath, char *dstPath);
+UINT24	mos_REN(char *srcPath, char *dstPath, BOOL verbose);
+UINT24	mos_COPY_API(char *srcPath, char *dstPath);
+UINT24	mos_COPY(char *srcPath, char *dstPath, BOOL verbose);
 UINT24	mos_MKDIR(char * filename);
 UINT24 	mos_EXEC(char * filename, char * buffer, UINT24 size);
 

--- a/src/mos.h
+++ b/src/mos.h
@@ -185,7 +185,10 @@ UINT8	fat_EOF(FIL * fp);
 							"   12: Swiss (French)\r\n" \
 							"   13: Danish\r\n" \
 							"   14: Swedish\r\n" \
-							"   15: Portuguese\r\n\r\n" \
+							"   15: Portuguese\r\n" \
+							"   16: Brazilian Portugese\r\n" \
+							"   17: Dvorak\r\n" \
+							"\r\n" \
 							"Serial Console\r\n" \
 							"SET CONSOLE n: Serial console\r\n" \
 							"    0: Console off (default)\r\n" \

--- a/src/mos.h
+++ b/src/mos.h
@@ -167,7 +167,7 @@ UINT8	fat_EOF(FIL * fp);
 #define HELP_SET			"Set a system option\r\n\r\n" \
 							"Keyboard Layout\r\n" \
 							"SET KEYBOARD n: Set the keyboard layout\r\n" \
-							"    0: UK\r\n" \
+							"    0: UK (default)\r\n" \
 							"    1: US\r\n" \
 							"    2: German\r\n" \
 							"    3: Italian\r\n" \
@@ -175,10 +175,17 @@ UINT8	fat_EOF(FIL * fp);
 							"    5: French\r\n" \
 							"    6: Belgian\r\n" \
 							"    7: Norwegian\r\n" \
-							"    8: Japanese\r\n\r\n" \
+							"    8: Japanese\r\n" \
+							"    9: US International\r\n" \
+							"   10: US International (alternative)\r\n" \
+							"   11: Swiss (German)\r\n" \
+							"   12: Swiss (French)\r\n" \
+							"   13: Danish\r\n" \
+							"   14: Swedish\r\n" \
+							"   15: Portuguese\r\n\r\n" \
 							"Serial Console\r\n" \
 							"SET CONSOLE n: Serial console\r\n" \
-							"    0: Console off\r\n" \
+							"    0: Console off (default)\r\n" \
 							"    1: Console on\r\n"
 #define HELP_SET_ARGS		"<option> <value>"
 

--- a/src/mos.h
+++ b/src/mos.h
@@ -116,6 +116,8 @@ void	mos_SETRTC(UINT24 address);
 UINT24	mos_SETINTVECTOR(UINT8 vector, UINT24 address);
 UINT24	mos_GETFIL(UINT8 fh);
 
+extern TCHAR	cwd[256];
+
 UINT8	fat_EOF(FIL * fp);
 
 #define HELP_CAT			"Directory listing of the current directory\r\n"

--- a/src/mos.h
+++ b/src/mos.h
@@ -87,7 +87,7 @@ int		mos_cmdTYPE(char *ptr);
 int		mos_cmdCLS(char *ptr);
 int		mos_cmdMOUNT(char *ptr);
 int		mos_cmdHELP(char *ptr);
-int		mos_cmdVDU(char *ptr);
+int		mos_cmdKEY(char *ptr);
 
 UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
@@ -202,6 +202,14 @@ UINT8	fat_EOF(FIL * fp);
 #define HELP_TYPE			"Display the contents of a file on the screen\r\n"
 #define HELP_TYPE_ARGS		"<filename>"
 
+#define HELP_KEY			"Store a command in one of 12 hotkey slots assigned to F1-F12\r\n\r\n" \
+							"Optionally, the command string can include \"%s\" as a marker\r\n" \
+							"in which case the hotkey command will be built either side.\r\n\r\n" \
+							"KEY without any arguments will list the currently assigned\r\n" \
+							"command strings.\r\n"
+							
+#define HELP_KEY_ARGS		"<key number> <command string>\r\n"
+
 #define HELP_CLS			"Clear the screen\r\n"
 
 #define HELP_MOUNT			"(Re-)mount the MicroSD card\r\n"
@@ -209,8 +217,8 @@ UINT8	fat_EOF(FIL * fp);
 #define HELP_HELP			"Display help on a single or all commands.\r\n"	\
 							"List of commands:\r\n"				\
 							"CAT, CD, CLS, COPY, CREDITS, DELETE, EXEC, \r\n"	\
-							"HELP, JMP, LOAD, MKDIR, MOUNT, RENAME, RUN, \r\n"	\
-							"SAVE, SET, TIME, TYPE, VDU.\r\n"
+							"HELP, KEY, JMP, LOAD, MKDIR, MOUNT, RENAME, \r\n"	\
+							"RUN, SAVE, SET, TIME, TYPE, VDU.\r\n"
 #define HELP_HELP_ARGS		"[ <command> | all ]"
 
 #endif MOS_H

--- a/src/mos.h
+++ b/src/mos.h
@@ -93,7 +93,7 @@ UINT24	mos_LOAD(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_SAVE(char * filename, UINT24 address, UINT24 size);
 UINT24	mos_TYPE(char * filename);
 UINT24	mos_CD(char * path);
-UINT24	mos_DIR(char * path);
+UINT24	mos_DIR(char * path, BOOL longListing);
 UINT24	mos_DEL(char * filename);
 UINT24 	mos_REN(char * filename1, char * filename2);
 UINT24	mos_COPY(char * filename1, char * filename2);
@@ -121,7 +121,7 @@ extern TCHAR	cwd[256];
 UINT8	fat_EOF(FIL * fp);
 
 #define HELP_CAT			"Directory listing of the current directory\r\n"
-#define HELP_CAT_ARGS		"<path>"
+#define HELP_CAT_ARGS		"[-l] <path>"
 #define HELP_CAT_ALIASES	"DIR and ."
 #define HELP_DIR_ALIASES	"CAT and ."
 #define HELP_DOT_ALIASES	"CAT and DIR"

--- a/src/mos.h
+++ b/src/mos.h
@@ -43,7 +43,6 @@ typedef struct {
 	int (*func)(char * ptr);
 	char * args;
 	char * help;
-	char * aliases;
 } t_mosCommand;
 
 typedef struct {
@@ -122,9 +121,6 @@ UINT8	fat_EOF(FIL * fp);
 
 #define HELP_CAT			"Directory listing of the current directory\r\n"
 #define HELP_CAT_ARGS		"[-l] <path>"
-#define HELP_CAT_ALIASES	"DIR and ."
-#define HELP_DIR_ALIASES	"CAT and ."
-#define HELP_DOT_ALIASES	"CAT and DIR"
 
 #define HELP_CD				"Change current directory\r\n"
 #define HELP_CD_ARGS		"<path>"
@@ -137,8 +133,6 @@ UINT8	fat_EOF(FIL * fp);
 
 #define HELP_DELETE			"Delete a file or folder (must be empty)\r\n"
 #define HELP_DELETE_ARGS	"<filename>"
-#define HELP_DELETE_ALIASES	"ERASE"
-#define HELP_ERASE_ALIASES	"DELETE"
 
 #define HELP_EXEC			"Run a batch file containing MOS commands\r\n"
 #define HELP_EXEC_ARGS		"<filename>"
@@ -156,8 +150,6 @@ UINT8	fat_EOF(FIL * fp);
 
 #define HELP_RENAME			"Rename a file in the same folder\r\n"
 #define HELP_RENAME_ARGS	"<filename1> <filename2>"
-#define HELP_RENAME_ALIASES	"MOVE"
-#define HELP_MOVE_ALIASES	"RENAME"
 
 #define HELP_RUN			"Call an executable binary loaded in memory.\r\n" \
 							"If no parameters are passed, then addr will " \
@@ -211,17 +203,14 @@ UINT8	fat_EOF(FIL * fp);
 							"KEY without any arguments will list the currently assigned\r\n" \
 							"command strings.\r\n"
 							
-#define HELP_KEY_ARGS		"<key number> <command string>\r\n"
+#define HELP_KEY_ARGS		"<key number> <command string>"
 
 #define HELP_CLS			"Clear the screen\r\n"
 
 #define HELP_MOUNT			"(Re-)mount the MicroSD card\r\n"
 
-#define HELP_HELP			"Display help on a single or all commands.\r\n"	\
-							"List of commands:\r\n"				\
-							"CAT, CD, CLS, COPY, CREDITS, DELETE, EXEC, \r\n"	\
-							"HELP, KEY, JMP, LOAD, MKDIR, MOUNT, RENAME, \r\n"	\
-							"RUN, SAVE, SET, TIME, TYPE, VDU.\r\n"
+#define HELP_HELP			"Display help on a single or all commands.\r\n"
+
 #define HELP_HELP_ARGS		"[ <command> | all ]"
 
 #endif MOS_H

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -97,8 +97,11 @@
 ;
 mos_api:		CP	80h			; Check if it is a FatFS command
 			JR	NC, $F			; Yes, so jump to next block
+			CP	mos_api_block1_size	; Check if out of bounds
+			RET	NC			; It is, so do nothing
 			CALL	SWITCH_A		; Switch on this table
-			DW	mos_api_getkey		; 0x00
+;
+mos_api_block1_start:	DW	mos_api_getkey		; 0x00
 			DW	mos_api_load		; 0x01
 			DW	mos_api_save		; 0x02
 			DW	mos_api_cd		; 0x03
@@ -133,10 +136,15 @@ mos_api:		CP	80h			; Check if it is a FatFS command
 			DW	mos_api_i2c_close	; 0x20
 			DW	mos_api_i2c_write	; 0x21
 			DW	mos_api_i2c_read	; 0x22
+
+mos_api_block1_size:	EQU 	($ - mos_api_block1_start) / 2
 ;			
 $$:			AND	7Fh			; Else remove the top bit
+			CP	mos_api_block2_size	; Check if out of bounds
+			RET	NC			; It is, so do nothing
 			CALL	SWITCH_A		; And switch on this table
-			DW	ffs_api_fopen
+
+mos_api_block2_start:	DW	ffs_api_fopen
 			DW	ffs_api_fclose
 			DW	ffs_api_fread
 			DW	ffs_api_fwrite
@@ -174,6 +182,8 @@ $$:			AND	7Fh			; Else remove the top bit
 			DW	ffs_api_getlabel
 			DW	ffs_api_setlabel
 			DW	ffs_api_setcp
+
+mos_api_block2_size:	EQU 	($ - mos_api_block2_start) / 2
 
 ; Get keycode
 ; Returns:

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -389,7 +389,7 @@ mos_api_mkdir:		LD	A, MB		; Check if MBASE is 0
 ; Finally, we can do the load
 ;
 			PUSH	HL		; char   * filename
-			CALL	_mos_MKDIR	; Call the C function mos_DEL
+			CALL	_mos_MKDIR	; Call the C function mos_MKDIR
 			LD	A, L		; Return vaue in HLU, put in A
 			POP	HL
 			RET

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -101,7 +101,7 @@
 mos_api:		CP	80h			; Check if it is a FatFS command
 			JR	NC, $F			; Yes, so jump to next block
 			CP	mos_api_block1_size	; Check if out of bounds
-			RET	NC			; It is, so do nothing
+			JP	NC, mos_api_not_implemented
 			CALL	SWITCH_A		; Switch on this table
 ;
 mos_api_block1_start:	DW	mos_api_getkey		; 0x00
@@ -144,7 +144,7 @@ mos_api_block1_size:	EQU 	($ - mos_api_block1_start) / 2
 ;			
 $$:			AND	7Fh			; Else remove the top bit
 			CP	mos_api_block2_size	; Check if out of bounds
-			RET	NC			; It is, so do nothing
+			JP	NC, mos_api_not_implemented
 			CALL	SWITCH_A		; And switch on this table
 
 mos_api_block2_start:	DW	ffs_api_fopen
@@ -187,6 +187,10 @@ mos_api_block2_start:	DW	ffs_api_fopen
 			DW	ffs_api_setcp
 
 mos_api_block2_size:	EQU 	($ - mos_api_block2_start) / 2
+
+mos_api_not_implemented:
+			LD	HL, 23			; FR_MOS_NOT_IMPLEMENTED
+			RET
 
 ; Get keycode
 ; Returns:
@@ -1069,7 +1073,7 @@ ffs_api_fprintf:
 ffs_api_ftell:		
 ffs_api_fsize:		
 ffs_api_ferror:		
-			RET
+			JP mos_api_not_implemented
 
 ; Open a directory
 ; HLU: Pointer to a blank DIR struct
@@ -1141,4 +1145,4 @@ ffs_api_getfree:
 ffs_api_getlabel:	
 ffs_api_setlabel:	
 ffs_api_setcp:		
-			RET
+			JP mos_api_not_implemented

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -1069,6 +1069,7 @@ ffs_api_fprintf:
 ffs_api_ftell:		
 ffs_api_fsize:		
 ffs_api_ferror:		
+			RET
 
 ; Open a directory
 ; HLU: Pointer to a blank DIR struct

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -92,6 +92,7 @@
 			XREF	_f_opendir
 			XREF	_f_closedir
 			XREF	_f_readdir
+			XREF	_f_getcwd
 			
 ; Call a MOS API function
 ; 00h - 7Fh: Reserved for high level MOS calls
@@ -1063,15 +1064,25 @@ $$:			PUSH	BC 		; FSIZE_t ofs (msb)
 ; Commands that have not been implemented yet
 ;
 ffs_api_ftruncate:	
+			JP mos_api_not_implemented
 ffs_api_fsync:		
+			JP mos_api_not_implemented
 ffs_api_fforward:	
+			JP mos_api_not_implemented
 ffs_api_fexpand:	
+			JP mos_api_not_implemented
 ffs_api_fgets:		
+			JP mos_api_not_implemented
 ffs_api_fputc:		
+			JP mos_api_not_implemented
 ffs_api_fputs:		
+			JP mos_api_not_implemented
 ffs_api_fprintf:	
+			JP mos_api_not_implemented
 ffs_api_ftell:		
+			JP mos_api_not_implemented
 ffs_api_fsize:		
+			JP mos_api_not_implemented
 ffs_api_ferror:		
 			JP mos_api_not_implemented
 
@@ -1129,20 +1140,52 @@ $$:
 			RET
 
 ffs_api_dfindfirst:	
+			JP mos_api_not_implemented
 ffs_api_dfindnext:	
+			JP mos_api_not_implemented
 ffs_api_unlink:		
+			JP mos_api_not_implemented
 ffs_api_rename:		
+			JP mos_api_not_implemented
 ffs_api_chmod:		
+			JP mos_api_not_implemented
 ffs_api_utime:		
+			JP mos_api_not_implemented
 ffs_api_mkdir:		
+			JP mos_api_not_implemented
 ffs_api_chdir:		
+			JP mos_api_not_implemented
 ffs_api_chdrive:	
-ffs_api_getcwd:		
+			JP mos_api_not_implemented
+; Copy the current directory (string) into buffer (hl)
+; HLU: Pointer to a buffer
+; BCU: Maximum length of buffer
+; Returns:
+; A: FRESULT
+ffs_api_getcwd:		LD	A, MB		; A: MB
+			OR	A, A 		; Check whether MB is 0, i.e. in 24-bit mode
+			JR	Z, $F		; It is, so skip as all addresses can be assumed to be 24-bit
+			CALL	SET_AHL24	; Convert HL to an address in segment A (MB)
+$$:
+			PUSH	BC 		; sizeof(buffer)
+			PUSH    HL		; buffer
+			CALL	_f_getcwd
+			LD	A, L		; FRESULT
+			POP	HL
+			POP	BC
+			RET
+
 ffs_api_mount:		
+			JP mos_api_not_implemented
 ffs_api_mkfs:		
+			JP mos_api_not_implemented
 ffs_api_fdisk		
+			JP mos_api_not_implemented
 ffs_api_getfree:	
+			JP mos_api_not_implemented
 ffs_api_getlabel:	
+			JP mos_api_not_implemented
 ffs_api_setlabel:	
+			JP mos_api_not_implemented
 ffs_api_setcp:		
 			JP mos_api_not_implemented

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -43,9 +43,9 @@
 			XREF	_mos_LOAD
 			XREF	_mos_SAVE
 			XREF	_mos_CD
-			XREF	_mos_DIR
+			XREF	_mos_DIR_API
 			XREF	_mos_DEL
-			XREF	_mos_REN
+			XREF	_mos_REN_API
 			XREF	_mos_FOPEN
 			XREF	_mos_FCLOSE
 			XREF	_mos_FGETC
@@ -53,7 +53,7 @@
 			XREF	_mos_FEOF
 			XREF	_mos_GETERROR
 			XREF	_mos_MKDIR
-			XREF	_mos_COPY
+			XREF	_mos_COPY_API
 			XREF	_mos_GETRTC 
 			XREF	_mos_SETRTC 
 			XREF	_mos_SETINTVECTOR
@@ -299,7 +299,7 @@ mos_api_dir:		LD	A, MB		; Check if MBASE is 0
 ; Finally, we can run the command
 ;
 			PUSH	HL		; char * path
-			CALL	_mos_DIR
+			CALL	_mos_DIR_API
 			LD	A, L		; Return value in HLU, put in A
 			POP	HL
 			RET
@@ -343,7 +343,7 @@ mos_api_ren:		LD	A, MB		; Check if MBASE is 0
 ; 
 $$:			PUSH	DE		; char * filename2
 			PUSH	HL		; char * filename1
-			CALL	_mos_REN	; Call the C function mos_REN
+			CALL	_mos_REN_API	; Call the C function mos_REN_API
 			LD	A, L		; Return vaue in HLU, put in A
 			POP	HL
 			POP	DE
@@ -368,7 +368,7 @@ mos_api_copy:		LD	A, MB		; Check if MBASE is 0
 ; 
 $$:			PUSH	DE		; char * filename2
 			PUSH	HL		; char * filename1
-			CALL	_mos_COPY	; Call the C function mos_COPY
+			CALL	_mos_COPY_API	; Call the C function mos_COPY_API
 			LD	A, L		; Return vaue in HLU, put in A
 			POP	HL
 			POP	DE

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -400,7 +400,28 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								const char *lastSpace = strrchr(buffer, ' ');
 								const char *lastSlash = strrchr(buffer, '/');
 								
-
+								if (lastSlash == NULL && lastSpace == NULL) { //Try commands first before fatfs completion
+									
+									search_term = (char*) malloc(strlen(buffer) + 6);
+									strcpy(search_term, buffer);
+									strcat(search_term, "*.bin");
+									
+									fr = f_findfirst(&dj, &fno, "/mos/", search_term);
+									
+									if (fr == FR_OK && fno.fname[0]) {
+										
+										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
+										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);
+										break;
+										
+									}
+									
+								}
+								
 								if (lastSlash != NULL) {
 									int pathLength = 1;
 																		

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -65,6 +65,19 @@ void getModeInformation() {
 	wait_VDP(0x10);								// Wait until the semaphore has been set, or a timeout happens
 }
 
+// Get palette entry
+//
+void readPalette(BYTE entry, BOOL wait) {
+	vpd_protocol_flags &= 0xFB;					// Clear the semaphore flag
+	putch(23);
+	putch(0);
+	putch(VDP_palette);
+	putch(entry);
+	if (wait) {
+		wait_VDP(0x04);							// Wait until the semaphore has been set, or a timeout happens
+	}
+}
+
 // Move cursor left
 //
 void doLeftCursor() {

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -434,10 +434,11 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 										free(search_term);
 										break;
 										
-									} else { //Otherwise try /bin/
-										
-										fr = f_findfirst(&dj, &fno, "/bin/", search_term);
-										if (!(fr == FR_OK && fno.fname[0])) break;
+									}
+									
+									//Try local .bin
+									fr = f_findfirst(&dj, &fno, "", search_term);
+									if ((fr == FR_OK && fno.fname[0])) {
 										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
 										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));
 										strcat(buffer, " ");
@@ -445,8 +446,20 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 										insertPos = strlen(buffer);										
 										free(search_term);
 										break;									
-										
+									}									
+									
+									//Otherwise try /bin/
+									fr = f_findfirst(&dj, &fno, "/bin/", search_term);
+									if ((fr == FR_OK && fno.fname[0])) {
+										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
+										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);
+										break;									
 									}
+									
 									
 								}
 								

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -396,6 +396,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								FRESULT fr;
 								DIR dj;
 								FILINFO fno;
+								t_mosCommand *cmd;
 								const char *searchTermStart;
 								const char *lastSpace = strrchr(buffer, ' ');
 								const char *lastSlash = strrchr(buffer, '/');
@@ -403,12 +404,27 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 								if (lastSlash == NULL && lastSpace == NULL) { //Try commands first before fatfs completion
 									
 									search_term = (char*) malloc(strlen(buffer) + 6);
+									
+									strcpy(search_term, buffer);
+									strcat(search_term, ".");
+									
+									cmd = mos_getCommand(search_term);
+									if (cmd != NULL) { //First try internal MOS commands
+										
+										printf("%s ", cmd->name + strlen(buffer));
+										strcat(buffer, cmd->name + strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);										
+										break;
+										
+									}
+									
 									strcpy(search_term, buffer);
 									strcat(search_term, "*.bin");
-									
 									fr = f_findfirst(&dj, &fno, "/mos/", search_term);
-									
-									if (fr == FR_OK && fno.fname[0]) {
+									if (fr == FR_OK && fno.fname[0]) { //Now try MOSlets
 										
 										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
 										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -434,6 +434,18 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 										free(search_term);
 										break;
 										
+									} else { //Otherwise try /bin/
+										
+										fr = f_findfirst(&dj, &fno, "/bin/", search_term);
+										if (!(fr == FR_OK && fno.fname[0])) break;
+										printf("%.*s ", strlen(fno.fname) - 4 - strlen(buffer), fno.fname + strlen(buffer));
+										strncat(buffer, fno.fname + strlen(buffer), strlen(fno.fname) - 4 - strlen(buffer));
+										strcat(buffer, " ");
+										len = strlen(buffer);
+										insertPos = strlen(buffer);										
+										free(search_term);
+										break;									
+										
 									}
 									
 								}

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -442,7 +442,6 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									int pathLength = 1;
 																		
 									if (lastSpace != NULL && lastSlash > lastSpace) {
-										lastSpace++;
 										pathLength = lastSlash - lastSpace; // Path starts after the last space and includes the slash
 									}
 									if (lastSpace == NULL) {
@@ -455,7 +454,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									if (path == NULL) {
 										break;
 									}
-									strncpy(path, lastSpace, pathLength); // Start after the last space
+									strncpy(path, lastSpace + 1, pathLength); // Start after the last space
 									path[pathLength] = '\0'; // Null-terminate the string
 
 									// Determine the start of the search term

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -388,6 +388,87 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear) {
 									}
 								}
 							} break;
+							
+							case 0x09: { // Tab
+								char *search_term;
+								char *path;
+
+								FRESULT fr;
+								DIR dj;
+								FILINFO fno;
+								const char *searchTermStart;
+								const char *lastSpace = strrchr(buffer, ' ');
+								const char *lastSlash = strrchr(buffer, '/');
+								
+
+								if (lastSlash != NULL) {
+									int pathLength = 1;
+																		
+									if (lastSpace != NULL && lastSlash > lastSpace) {
+										lastSpace++;
+										pathLength = lastSlash - lastSpace; // Path starts after the last space and includes the slash
+									}
+									if (lastSpace == NULL) {
+										lastSpace = buffer;
+										pathLength = lastSlash - lastSpace;
+										
+									}
+
+									path = (char*) malloc(pathLength + 1); // +1 for null terminator
+									if (path == NULL) {
+										break;
+									}
+									strncpy(path, lastSpace, pathLength); // Start after the last space
+									path[pathLength] = '\0'; // Null-terminate the string
+
+									// Determine the start of the search term
+									searchTermStart = lastSlash + 1;
+									if (lastSpace != NULL && lastSpace > lastSlash) {
+										searchTermStart = lastSpace + 1;
+									}
+									search_term = (char*) malloc(strlen(searchTermStart) + 2); // +2 for '*' and null terminator
+								} else {
+									
+									path = (char*) malloc(1);
+									if (path == NULL) {
+										break;
+									}
+									path[0] = '\0'; // Path is empty (current dir, essentially).
+
+									searchTermStart = lastSpace ? lastSpace + 1 : buffer;
+									search_term = (char*) malloc(strlen(searchTermStart) + 2); // +2 for '*' and null terminator
+								}
+
+								if (search_term == NULL) {
+									free(path);
+									break;
+								}
+
+								strcpy(search_term, lastSpace && lastSlash > lastSpace ? lastSlash + 1 : lastSpace ? lastSpace + 1 : buffer);
+								strcat(search_term, "*");
+								
+								//printf("Path:\"%s\" Pattern:\"%s\"\r\n", path, search_term);
+								fr = f_findfirst(&dj, &fno, path, search_term);
+								
+								if (fr == FR_OK && fno.fname[0]) {
+
+									if (fno.fattrib & AM_DIR) printf("%s/", fno.fname + strlen(search_term) - 1);
+									else printf("%s", fno.fname + strlen(search_term) - 1);
+
+									strcat(buffer, fno.fname + strlen(search_term) - 1);
+									if (fno.fattrib & AM_DIR) strcat(buffer, "/");
+
+									len = strlen(buffer);
+									insertPos = strlen(buffer);
+									
+								}
+
+								// Free the allocated memory
+								free(search_term);
+								free(path);
+
+							} break;							
+							
 							case 0x7F: {	// Backspace
 								if (deleteCharacter(buffer, insertPos, len)) {
 									insertPos--;

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -17,4 +17,6 @@
 
 UINT24	mos_EDITLINE(char * filename, int bufferLength, UINT8 clear);
 
+extern char	*hotkey_strings[12];
+
 #endif MOS_EDITOR_H

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -16,6 +16,8 @@
 #define cmd_historyDepth	16
 
 UINT24	mos_EDITLINE(char * filename, int bufferLength, UINT8 clear);
+void getModeInformation();
+void readPalette(BYTE entry, BOOL wait);
 
 extern char	*hotkey_strings[12];
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -6,6 +6,8 @@
  */
  
 #include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
 
 int strcasecmp(const char *s1, const char *s2)
 {
@@ -22,3 +24,31 @@ int strcasecmp(const char *s1, const char *s2)
 	return result;
 }
 
+//Alternative to missing strnlen() in ZDS libraries
+size_t mos_strnlen(const char *s, size_t maxlen) {
+    size_t len = 0;
+    while (len < maxlen && s[len] != '\0') {
+        len++;
+    }
+    return len;
+}
+
+//Alternative to missing strdup() in ZDS libraries
+char *mos_strdup(const char *s) {
+    char *d = malloc(strlen(s) + 1);  // Allocate memory
+    if (d != NULL) strcpy(d, s);      // Copy the string
+    return d;
+}
+
+//Alternative to missing strndup() in ZDS libraries
+char *mos_strndup(const char *s, size_t n) {
+    size_t len = mos_strnlen(s, n);
+    char *d = malloc(len + 1);  // Allocate memory for length plus null terminator
+
+    if (d != NULL) {
+        strncpy(d, s, len);  // Copy up to len characters
+        d[len] = '\0';       // Null-terminate the string
+    }
+
+    return d;
+}

--- a/src/strings.h
+++ b/src/strings.h
@@ -12,4 +12,12 @@
 
 extern int strcasecmp(const char *s1, const char *s2);
 
+size_t mos_strnlen(const char *s, size_t maxlen);
+
+//Alternative to missing strdup() in ZDS libraries
+char *mos_strdup(const char *s);
+
+//Alternative to missing strndup() in ZDS libraries
+char *mos_strndup(const char *s, size_t n);
+
 #endif // STRINGS_H

--- a/src/version.h
+++ b/src/version.h
@@ -4,8 +4,8 @@
 #define		VERSION_MAJOR		2
 #define		VERSION_MINOR		2
 #define		VERSION_PATCH		0
-#define		VERSION_CANDIDATE	1			// Optional
-#define		VERSION_TYPE		"Test "	// RC, Alpha, Beta, etc.
+// #define		VERSION_CANDIDATE	1			// Optional
+// #define		VERSION_TYPE		"Test "	// RC, Alpha, Beta, etc.
 
 #define		VERSION_VARIANT		"Console8"
 #define     VERSION_SUBTITLE    "Rainbow"

--- a/src/version.h
+++ b/src/version.h
@@ -2,11 +2,12 @@
 #define VERSION_H
 
 #define		VERSION_MAJOR		2
-#define		VERSION_MINOR		1
+#define		VERSION_MINOR		2
 #define		VERSION_PATCH		0
-// #define		VERSION_CANDIDATE	0			// Optional
-// #define		VERSION_TYPE		"Release"	// RC, Alpha, Beta, etc.
+#define		VERSION_CANDIDATE	1			// Optional
+#define		VERSION_TYPE		"Test "	// RC, Alpha, Beta, etc.
 
 #define		VERSION_VARIANT		"Console8"
+#define     VERSION_SUBTITLE    "Rainbow"
 
 #endif // VERSION_H

--- a/src_fatfs/ff.c
+++ b/src_fatfs/ff.c
@@ -2435,7 +2435,7 @@ static FRESULT dir_register (	/* FR_OK:succeeded, FR_DENIED:no free entry or too
 	DIR* dp						/* Target directory with object name to be created */
 )
 {
-	FRESULT res;
+	FRESULT res = FR_INT_ERR;
 	FATFS *fs = dp->obj.fs;
 #if FF_USE_LFN		/* LFN configuration */
 	UINT n, len, n_ent;

--- a/src_fatfs/ff.h
+++ b/src_fatfs/ff.h
@@ -306,6 +306,7 @@ typedef enum {
 	FR_MOS_INVALID_COMMAND, /* (20) */
 	FR_MOS_INVALID_EXECUTABLE, /* (21) */
 	FR_MOS_OUT_OF_MEMORY, /* (22) */
+	FR_MOS_NOT_IMPLEMENTED, /* (23) */
 } FRESULT;
 
 

--- a/src_fatfs/ff.h
+++ b/src_fatfs/ff.h
@@ -274,7 +274,12 @@ typedef struct {
 
 
 
-/* File function return code (FRESULT) */
+/**
+ * File function return code (FRESULT)
+ *
+ * Also used as MOS user program return codes, and augmented with non-fatfs codes
+ * (see FR_MOS_xxx)
+ */
 
 typedef enum {
 	FR_OK = 0,				/* (0) Succeeded */
@@ -296,7 +301,11 @@ typedef enum {
 	FR_LOCKED,				/* (16) The operation is rejected according to the file sharing policy */
 	FR_NOT_ENOUGH_CORE,		/* (17) LFN working buffer could not be allocated */
 	FR_TOO_MANY_OPEN_FILES,	/* (18) Number of open files > FF_FS_LOCK */
-	FR_INVALID_PARAMETER	/* (19) Given parameter is invalid */
+	FR_INVALID_PARAMETER,	/* (19) Given parameter is invalid */
+	// additional error codes specific to MOS
+	FR_MOS_INVALID_COMMAND, /* (20) */
+	FR_MOS_INVALID_EXECUTABLE, /* (21) */
+	FR_MOS_OUT_OF_MEMORY, /* (22) */
 } FRESULT;
 
 

--- a/src_fatfs/ffconf.h
+++ b/src_fatfs/ffconf.h
@@ -39,7 +39,7 @@
 /   3: f_lseek() function is removed in addition to 2. */
 
 
-#define FF_USE_FIND		0
+#define FF_USE_FIND		1
 /* This option switches filtered directory read functions, f_findfirst() and
 /  f_findnext(). (0:Disable, 1:Enable 2:Enable with matching altname[] too) */
 


### PR DESCRIPTION
Incorporates _most_ of the changes from the "rainbow" MOS that @tomm has been experimenting with

To briefly summarise, that includes:
* changes/fixes from @breakintoprogram (added to the Quark codebase since 1.04 - currently unreleased)
* "comment" commands from @sadbeast
* enhanced VDU command from @HeathenUK 
* tab command completion from @HeathenUK 
* hotkey support from @HeathenUK
* support for a `bin` directory from @HeathenUK 
* directory listing enhancements from @tomm 

Also includes:
* some minor fixes
* smarter "help" command
* confirmation step for wild-card delete
* line editor now supports flags to control whether tab-completion, hotkeys and history are enabled

The current intent is that this will form the basis of a new 2.2.0 MOS release