### PR TITLE
fix issues around copy and dir

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -634,8 +634,8 @@ int mos_cmdDEL(char * ptr) {
 			dirPath = mos_strdup(".");
 			pattern = mos_strdup(filename);
 			if (!dirPath || !pattern) {
-				free(dirPath);
-				free(pattern);
+				if (dirPath) free(dirPath);
+				if (pattern) free(pattern);
 				return FR_INT_ERR;
 			}
         }
@@ -697,8 +697,8 @@ int mos_cmdDEL(char * ptr) {
 	}
 
 	cleanup:
-		free(dirPath);
-		free(pattern);
+		if (dirPath) free(dirPath);
+		if (pattern) free(pattern);
 		return fr;
 }
 
@@ -1363,6 +1363,7 @@ UINT24 mos_DIR(char* inputPath, BOOL longListing) {
             filenameLength = strlen(filinfo.fname) + 1;
             fnos[fno_num].fname = malloc(filenameLength);
 			if (!fnos[fno_num].fname) {
+				// TODO if we're failing here, we need to do an alternate directory display
 				fr = FR_INT_ERR;
 				break;
 			}
@@ -1434,8 +1435,8 @@ UINT24 mos_DIR(char* inputPath, BOOL longListing) {
     }
 
 cleanup:
-    free(pattern);
-    free(dirPath);
+    if (pattern) free(pattern);
+    if (dirPath) free(dirPath);
     return fr;
 }
 
@@ -1536,8 +1537,8 @@ UINT24 mos_REN(char *srcPath, char *dstPath, BOOL verbose) {
 
             if (!fullSrcPath || !fullDstPath) {
                 fr = FR_INT_ERR; // Out of memory
-                free(fullSrcPath);
-                free(fullDstPath);
+                if (fullSrcPath) free(fullSrcPath);
+                if (fullDstPath) free(fullDstPath);
                 break;
             }
 
@@ -1579,8 +1580,8 @@ UINT24 mos_REN(char *srcPath, char *dstPath, BOOL verbose) {
     }
 
 cleanup:
-    free(srcDir);
-    free(pattern);
+    if (srcDir) free(srcDir);
+    if (pattern) free(pattern);
     return fr;
 }
 
@@ -1682,8 +1683,8 @@ UINT24 mos_COPY(char *srcPath, char *dstPath, BOOL verbose) {
             f_close(&fdst);
 
         file_cleanup:
-            free(fullSrcPath);
-            free(fullDstPath);
+            if (fullSrcPath) free(fullSrcPath);
+            if (fullDstPath) free(fullDstPath);
             fullSrcPath = NULL;
             fullDstPath = NULL;
 
@@ -1730,10 +1731,10 @@ UINT24 mos_COPY(char *srcPath, char *dstPath, BOOL verbose) {
     }
 
 cleanup:
-    free(srcDir);
-    free(pattern);
-    free(fullSrcPath);
-    free(fullDstPath);
+    if (srcDir) free(srcDir);
+    if (pattern) free(pattern);
+    if (fullSrcPath) free(fullSrcPath);
+    if (fullDstPath) free(fullDstPath);
     return fr;
 }
 

--- a/src/mos.c
+++ b/src/mos.c
@@ -1808,7 +1808,7 @@ UINT24 mos_COPY(char *srcPath, char *dstPath, BOOL verbose) {
             return fr;
         }
 
-		if (verbose) printf("Moving %s to %s\r\n", fullSrcPath, fullDstPath);
+		if (verbose) printf("Copying %s to %s\r\n", srcPath, fullDstPath);
         while (1) {
             fr = f_read(&fsrc, buffer, sizeof(buffer), &br);
             if (br == 0 || fr != FR_OK) break;

--- a/src/mos.c
+++ b/src/mos.c
@@ -1320,7 +1320,7 @@ UINT24 mos_DIR(char* inputPath, BOOL longListing) {
     BYTE           textFg = 15;
     BYTE           dirColour = 2;
     BYTE           fileColour = 15;
-    SmallFilInfo * fnos, *fno;
+    SmallFilInfo * fnos = NULL, *fno = NULL;
     int            num_dirents, fno_num;
 
     fr = f_getlabel("", str, 0);
@@ -1395,18 +1395,6 @@ UINT24 mos_DIR(char* inputPath, BOOL longListing) {
         }
     }
 
-    fr = get_num_dirents(dirPath, &num_dirents);
-
-    if (num_dirents == 0)
-        return fr;
-
-    fnos = malloc(sizeof(SmallFilInfo) * num_dirents);
-	// TODO rather than just bailing here, skip to alternate non-sorted method of listing
-	if (!fnos) {
-		fr = mos_DIRFallback(inputPath, longListing, FALSE);
-		goto cleanup;
-	}
-
     fno_num = 0;
     fr = f_opendir(&dir, dirPath);
 
@@ -1424,6 +1412,19 @@ UINT24 mos_DIR(char* inputPath, BOOL longListing) {
             printf("Directory: %s\r\n\r\n", cwd);
         } else
             printf("Directory: %s\r\n\r\n", dirPath);
+
+		fr = get_num_dirents(dirPath, &num_dirents);
+
+		if (num_dirents == 0) {
+			printf("No files found\r\n");
+			goto cleanup;
+		}
+
+		fnos = malloc(sizeof(SmallFilInfo) * num_dirents);
+		if (!fnos) {
+			fr = mos_DIRFallback(inputPath, longListing, FALSE);
+			goto cleanup;
+		}
 
         if (usePattern) {
             fr = f_findfirst(&dir, &filinfo, dirPath, pattern);

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -507,7 +507,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 flags) {
 								}
 
 								if (search_term == NULL) {
-									free(path);
+									if (path) free(path);
 									break;
 								}
 
@@ -529,8 +529,8 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 flags) {
 								}
 
 								// Free the allocated memory
-								free(search_term);
-								free(path);
+								if (search_term) free(search_term);
+								if (path) free(path);
 							}
 							break;							
 							

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -237,6 +237,10 @@ BOOL handleHotkey(UINT8 fkey, char * buffer, int bufferLength, int insertPos, in
 			}
 
 			result = malloc(prefixLength + replacementLength + suffixLength + 1); // +1 for null terminator
+			if (!result) {
+				// Memory allocation failed
+				return 0;
+			}
 
 			strncpy(result, hotkey_strings[fkey], prefixLength); // Copy the portion preceding the wildcard to the buffer
 			result[prefixLength] = '\0'; // Terminate
@@ -392,8 +396,8 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 flags) {
 							} break;
 							
 							case 0x09: if (enableTab) { // Tab
-								char *search_term;
-								char *path;
+								char *search_term = NULL;
+								char *path = NULL;
 
 								FRESULT fr;
 								DIR dj;
@@ -406,6 +410,10 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 flags) {
 								if (lastSlash == NULL && lastSpace == NULL) { //Try commands first before fatfs completion
 									
 									search_term = (char*) malloc(strlen(buffer) + 6);
+									if (!search_term) {
+										// malloc failed, so no tab completion for us today
+										break;
+									}
 									
 									strcpy(search_term, buffer);
 									strcat(search_term, ".");

--- a/src/version.h
+++ b/src/version.h
@@ -3,7 +3,7 @@
 
 #define		VERSION_MAJOR		2
 #define		VERSION_MINOR		2
-#define		VERSION_PATCH		0
+#define		VERSION_PATCH		1
 // #define		VERSION_CANDIDATE	1			// Optional
 // #define		VERSION_TYPE		"Test "	// RC, Alpha, Beta, etc.
 


### PR DESCRIPTION
the 2.2.0 release included a significant bug in copy which could cause screen corruption.  additionally it was found that copy could only copy files to a separate (different) destination directory, rather than to an explicit filename

directory listing was found to be not functional on a freshly booted machine that booted into ADL BASIC

additionally directory listing would show no output at all when an empty directory was found, and could also show only partial output if a `malloc` had failed

this PR addresses all of theses issues
