### PR TITLE
Cleanup of mos_cmdRUN()

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -727,13 +727,10 @@ int mos_cmdJMP(char *ptr) {
 //
 int mos_cmdRUN(char *ptr) {
 	UINT24 	addr;
-	UINT8	mode;
-	void (* dest)(void) = 0;
 	
 	if(!mos_parseNumber(NULL, &addr)) {
 		addr = MOS_defaultLoadAddress;
 	}
-	mode = mos_execMode((UINT8 *)addr);
 	return mos_runBin(addr);
 }
 


### PR DESCRIPTION
mos_cmdRUN() invokes mos_execMode() to determine ADL/ez80 execution mode, before calling mos_runBin(). However this is the first thing mos_runBin() also does based on the previously loaded memory content.

I've removed this superfluous invocation and also removed an unused stack variable *dest;
