### PR TITLE
chore(): add missing colon

### DIFF
--- a/src/mos_api.inc
+++ b/src/mos_api.inc
@@ -123,7 +123,7 @@ ffs_getcwd:		EQU	9Eh
 ;
 ffs_mount:		EQU	9Fh
 ffs_mkfs:		EQU	A0h
-ffs_fdisk		EQU	A1h
+ffs_fdisk:		EQU	A1h
 ffs_getfree:		EQU	A2h
 ffs_getlabel:		EQU	A3h
 ffs_setlabel:		EQU	A4h


### PR DESCRIPTION
**Fixes missing colon**

A missing colon was identified on line 126 of `mos_api.inc` after the the declaration of the `ffs_fdisk` equate.

This pull request addresses build failures when including `src/mos_api.inc` in projects caused by the missing colon. No other changes have been made. Adding the colon resolves the syntax error and allows build that include `src/mos_api.inc` to complete successfully.

The agon-mos project itself does not use `src/mos_api.inc` when building, so this syntax does not break the build of this project, it only breaks builds of projects that include `src/mos_api.inc`.

This fix should ensure smoother integration of the file in projects.