### PR TITLE
Move CLI history into the heap

### DIFF
--- a/main.c
+++ b/main.c
@@ -202,8 +202,7 @@ int main(void) {
 	mos_mount();									// Mount the SD card
 
 	putch(7);										// Startup beep
-	history_no = 0;
-	history_size = 0;
+	editHistoryInit();								// Initialise the command history
 
 	// Load the autoexec.bat config file
 	//

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -592,7 +592,14 @@ void editHistoryPush(char *buffer) {
 	int len = strlen(buffer);
 
 	if (len > 0) {		// If there is data in the buffer
-		char *newEntry = umm_malloc(len + 1);
+		char * newEntry = NULL;
+
+		// if the new entry is the same as the last entry, then don't save it
+		if (history_size > 0 && strcmp(buffer, cmd_history[history_size - 1]) == 0) {
+			return;
+		}
+
+		newEntry = umm_malloc(len + 1);
 		if (newEntry == NULL) {
 			// Memory allocation failed so we can't save history
 			return;

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -19,6 +19,10 @@ UINT24	mos_EDITLINE(char * filename, int bufferLength, UINT8 clear);
 void getModeInformation();
 void readPalette(BYTE entry, BOOL wait);
 
+void editHistoryPush(char *buffer);
+BOOL editHistoryUp(char *buffer, int insertPos, int len, int limit);
+BOOL editHistoryDown(char *buffer, int insertPos, int len, int limit);
+
 extern char	*hotkey_strings[12];
 
 #endif MOS_EDITOR_H

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -19,6 +19,7 @@ UINT24	mos_EDITLINE(char * filename, int bufferLength, UINT8 clear);
 void getModeInformation();
 void readPalette(BYTE entry, BOOL wait);
 
+void editHistoryInit();
 void editHistoryPush(char *buffer);
 BOOL editHistoryUp(char *buffer, int insertPos, int len, int limit);
 BOOL editHistoryDown(char *buffer, int insertPos, int len, int limit);

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -23,6 +23,7 @@ void editHistoryInit();
 void editHistoryPush(char *buffer);
 BOOL editHistoryUp(char *buffer, int insertPos, int len, int limit);
 BOOL editHistoryDown(char *buffer, int insertPos, int len, int limit);
+BOOL editHistorySet(char *buffer, int insertPos, int len, int limit, int index);
 
 extern char	*hotkey_strings[12];
 


### PR DESCRIPTION
Changes how CLI history is recorded, moving it from a static fixed length array of chars to storing pointers to variable length strings in the heap

Duplicate history items are no longer pushed, altho this check is only against the most recent history entry

This gives us a chunk more heap space