### PR TITLE
Fix issues discovered in 2.3.0

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -41,7 +41,7 @@ extern void _low_romdata[];
 extern int _len_data;
 
 
-#define SPL_STACK_SIZE				1536
+#define SPL_STACK_SIZE				2048
 #define HEAP_LEN ((int)_stack - (int)_heapbot - SPL_STACK_SIZE)
 
 // VDP specific (for VDU 23,0,n commands)

--- a/src/mos.c
+++ b/src/mos.c
@@ -518,8 +518,12 @@ int mos_cmdECHO(char *ptr) {
 					p++;
 				} else if (*p == '!') {
 					// prints next character with top bit set
-					putch(*p | 0x80);
 					p++;
+					if (*p == 0) {
+						// no more characters, so this is an error
+						return MOS_BAD_STRING;
+					}
+					putch(*p++ | 0x80);
 				} else if (*p >= 0x40 && *p < 0x7F) {
 					// characters from &40-7F (letters and some punctuation)
 					// are printed as just their bottom 5 bits

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -281,7 +281,8 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT8 flags) {
 	int  limit = bufferLength - 1;	// Max # of characters that can be entered
 	int	 insertPos;					// The insert position
 	int  len = 0;					// Length of current input
-	
+	history_no = history_size;		// Ensure our current "history" is the end of the list
+
 	getModeInformation();			// Get the current screen dimensions
 	
 	if (clear) {					// Clear the buffer as required
@@ -616,7 +617,6 @@ void editHistoryPush(char *buffer) {
 			history_size--;
 		}
 		cmd_history[history_size++] = newEntry;
-		history_no = history_size;
 	}
 }
 

--- a/src/strings.c
+++ b/src/strings.c
@@ -1,55 +1,58 @@
 /*
  * Title:			AGON MOS - Additional string functions
- * Author:			Leigh Brown
+ * Author:			Leigh Brown, HeathenUK, and others
  * Created:			24/05/2023
- * Last Updated:	24/05/2023
  */
- 
+
 #include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include "umm_malloc.h"
 
-int strcasecmp(const char *s1, const char *s2)
-{
+int strcasecmp(const char *s1, const char *s2) {
 	const unsigned char *p1 = (const unsigned char *)s1;
 	const unsigned char *p2 = (const unsigned char *)s2;
 	int result;
 
-	if (p1 == p2)
+	if (p1 == p2) {
 		return 0;
+	}
 
-	while ((result = tolower (*p1) - tolower (*p2++)) == 0)
-		if (*p1++ == '\0')
+	while ((result = tolower(*p1) - tolower(*p2++)) == 0) {
+		if (*p1++ == '\0') {
 			break;
+		}
+	}
 	return result;
 }
 
-//Alternative to missing strnlen() in ZDS libraries
+// Alternative to missing strnlen() in ZDS libraries
 size_t mos_strnlen(const char *s, size_t maxlen) {
-    size_t len = 0;
-    while (len < maxlen && s[len] != '\0') {
-        len++;
-    }
-    return len;
+	size_t len = 0;
+	while (len < maxlen && s[len] != '\0') {
+		len++;
+	}
+	return len;
 }
 
-//Alternative to missing strdup() in ZDS libraries
-char *mos_strdup(const char *s) {
-    char *d = umm_malloc(strlen(s) + 1);  // Allocate memory
-    if (d != NULL) strcpy(d, s);      // Copy the string
-    return d;
+// Alternative to missing strdup() in ZDS libraries
+char * mos_strdup(const char *s) {
+	char *d = umm_malloc(strlen(s) + 1);  // Allocate memory
+	if (d != NULL) {
+		strcpy(d, s);      // Copy the string
+	}
+	return d;
 }
 
-//Alternative to missing strndup() in ZDS libraries
-char *mos_strndup(const char *s, size_t n) {
-    size_t len = mos_strnlen(s, n);
-    char *d = umm_malloc(len + 1);  // Allocate memory for length plus null terminator
+// Alternative to missing strndup() in ZDS libraries
+char * mos_strndup(const char *s, size_t n) {
+	size_t len = mos_strnlen(s, n);
+	char *d = umm_malloc(len + 1);  // Allocate memory for length plus null terminator
 
-    if (d != NULL) {
-        strncpy(d, s, len);  // Copy up to len characters
-        d[len] = '\0';       // Null-terminate the string
-    }
+	if (d != NULL) {
+		strncpy(d, s, len);  // Copy up to len characters
+		d[len] = '\0';       // Null-terminate the string
+	}
 
-    return d;
+	return d;
 }


### PR DESCRIPTION
Bumps up stack space to 2kb, fixing an issue observed with the `copy` command causing crashes from the MOS CLI

Fixes an issue observed with `echo` where `|!` token wasn't being correctly interpreted

Fixes #87 where history could slightly misbehave when not pushing a new item