### PR TITLE
set up MOS for full-duplex comms

### DIFF
--- a/main.c
+++ b/main.c
@@ -50,7 +50,7 @@
 #include "i2c.h"
 #include "umm_malloc.h"
 
-extern BYTE scrcolours, scrpixelIndex;  // In globals.asm
+extern BYTE scrcolours, scrpixelIndex;	// In globals.asm
 
 extern void *	set_vector(unsigned int vector, void(*handler)(void));
 
@@ -83,20 +83,29 @@ void wait_ESP32(UART * pUART, UINT24 baudRate) {
 	pUART->interrupts = UART_IER_RECEIVEINT;
 
 	open_UART0(pUART);					// Open the UART 
-	init_timer0(10, 16, 0x00);  		// 10ms timer for delay
+	init_timer0(10, 16, 0x00);			// 10ms timer for delay
 
 	gp = 0;
 	while (gp == 0) {					// Wait for the ESP32 to respond with a GP packet
 		putch(23);						// Send a general poll packet
 		putch(0);
 		putch(VDP_gp);
-		putch(2);						// Poll VDP with a GP of 2 to request full-duplex
+		putch(1);
 		for (i = 0; i < 5; i++) {		// Wait 50ms
 			if (gp != 0) break;
 			wait_timer0();
 		}
 	}
 	enable_timer0(0);					// Disable the timer
+
+	// Set feature flag for full-duplex, flag 0x0101, non-zero 16-bit value
+	putch(23);
+	putch(0);
+	putch(VDP_feature);
+	putch(0x01);
+	putch(0x01);
+	putch(0x01);
+	putch(0x00);
 }
 
 // Initialise the interrupts
@@ -176,7 +185,7 @@ int main(void) {
 	scrcolours = 0;
 	scrpixelIndex = 255;
 	getModeInformation();
-    while (scrcolours == 0) { }
+	while (scrcolours == 0) { }
 	readPalette(128, TRUE);
 
 	if (scrpixelIndex < 128) {

--- a/main.c
+++ b/main.c
@@ -71,10 +71,8 @@ extern BOOL	vdpSupportsTextPalette;
 // Parameters:
 // - pUART: Pointer to a UART structure
 // - baudRate: Baud rate to initialise UART with
-// Returns:
-// - 1 if the function succeeded, otherwise 0
 //
-int wait_ESP32(UART * pUART, UINT24 baudRate) {	
+void wait_ESP32(UART * pUART, UINT24 baudRate) {	
 	int	i, t;
 
 	pUART->baudRate = baudRate;			// Initialise the UART object
@@ -86,19 +84,19 @@ int wait_ESP32(UART * pUART, UINT24 baudRate) {
 
 	open_UART0(pUART);					// Open the UART 
 	init_timer0(10, 16, 0x00);  		// 10ms timer for delay
-	gp = 0;								// Reset the general poll byte	
-	for(t = 0; t < 200; t++) {			// A timeout loop (200 x 50ms = 10s)
+
+	gp = 0;
+	while (gp == 0) {					// Wait for the ESP32 to respond with a GP packet
 		putch(23);						// Send a general poll packet
 		putch(0);
 		putch(VDP_gp);
-		putch(1);
-		for(i = 0; i < 5; i++) {		// Wait 50ms
+		putch(2);						// Poll VDP with a GP of 2 to request full-duplex
+		for (i = 0; i < 5; i++) {		// Wait 50ms
+			if (gp != 0) break;
 			wait_timer0();
 		}
-		if(gp == 1) break;				// If general poll returned, then exit for loop
 	}
 	enable_timer0(0);					// Disable the timer
-	return gp;
 }
 
 // Initialise the interrupts
@@ -167,12 +165,9 @@ int main(void) {
 	init_UART1();									// Initialise UART1
 	EI();											// Enable the interrupts now
 	
-	if(!wait_ESP32(&pUART0, 1152000)) {				// Try to lock onto the ESP32 at maximum rate
-		if(!wait_ESP32(&pUART0, 384000))	{		// If that fails, then fallback to the lower baud rate
-			gp = 2;									// Flag GP as 2, just in case we need to handle this error later
-		}
-	}	
-	if(coldBoot == 0) {								// If a warm boot detected then
+	wait_ESP32(&pUART0, 1152000);					// Connect to VDP at maximum rate
+
+	if (coldBoot == 0) {							// If a warm boot detected then
 		putch(12);									// Clear the screen
 	}
 

--- a/src/defines.h
+++ b/src/defines.h
@@ -68,8 +68,9 @@ typedef enum {
 #define VDP_mode				0x86
 #define VDP_rtc					0x87
 #define VDP_keystate			0x88
-#define VDP_palette             0x94
+#define VDP_palette				0x94
 #define VDP_logicalcoords		0xC0
+#define VDP_feature				0xF8
 #define VDP_consolemode			0xFE
 #define VDP_terminalmode		0xFF
 

--- a/src/serial.asm
+++ b/src/serial.asm
@@ -75,8 +75,9 @@ UART_LSR_RDY		EQU	%01		; Data ready
 
 ; Check whether we're clear to send (UART0 only)
 ;
-UART0_wait_CTS:		GET_GPIO	PD_DR, 8		; Check Port D, bit 3 (CTS)
-			JR		NZ, UART0_wait_CTS
+UART0_wait_CTS:		IN0		A, (UART0_REG_MSR)
+			BIT		4, A			; check inverted CTS bit, 1 = CTS, 0 = NOT CTS (clear to send)
+			JR		Z, UART0_wait_CTS
 			RET
 
 UART1_wait_CTS:		GET_GPIO	PC_DR, 8		; Check Port C, bit 3 (CTS)
@@ -186,7 +187,7 @@ $$:			CALL 		UART0_serial_RX
 ;
 UART1_serial_GETCH:	PUSH		AF 
 			LD		A, (_serialFlags)
-			TST		01h
+			TST		10h
 			JR		Z, UART_serial_NE
 			POP		AF
 $$:			CALL 		UART1_serial_RX

--- a/src/uart.c
+++ b/src/uart.c
@@ -73,10 +73,10 @@ BYTE open_UART0(UART * pUART) {
 	RESETREG(PD_ALT1, pins);
 	SETREG(PD_ALT2, pins);
 
-	if(pUART->flowControl == FCTL_HW) {
-		SETREG(PD_DDR, PORTPIN_THREE);								// Set Port D bit 3 (CTS) for input
-		RESETREG(PD_ALT1, PORTPIN_THREE);
-		RESETREG(PD_ALT2, PORTPIN_THREE);
+	if (pUART->flowControl == FCTL_HW) {
+		SETREG(PD_DDR, PORTPIN_THREE | PORTPIN_TWO);				// Set Port D bit 3 and 2 (CTS,RTS) to alternate function
+		RESETREG(PD_ALT1, PORTPIN_THREE | PORTPIN_TWO);
+		SETREG(PD_ALT2, PORTPIN_THREE | PORTPIN_TWO);
 		serialFlags |= 0x02;
 	}
 
@@ -84,7 +84,7 @@ BYTE open_UART0(UART * pUART) {
 	UART0_BRG_L = (br & 0xFF);										// Load divisor low
 	UART0_BRG_H = (CHAR)(( br & 0xFF00 ) >> 8);						// Load divisor high
 	UART0_LCTL &= (~UART_LCTL_DLAB); 								// Reset DLAB; dont disturb other bits
-	UART0_MCTL = 0x00;												// Bring modem control register to reset value
+	UART0_MCTL = 0x02;												// Multidrop, loopback, DTR disabled, RTS enabled
 	UART0_FCTL = 0x07;												// Enable and clear hardware FIFOs
 	UART0_IER = pUART->interrupts;									// Set interrupts
 	
@@ -112,7 +112,7 @@ BYTE open_UART1(UART * pUART) {
 	RESETREG(PC_ALT1, pins);
 	SETREG(PC_ALT2, pins);
 
-	if(pUART->flowControl == FCTL_HW) {
+	if (pUART->flowControl == FCTL_HW) {
 		SETREG(PC_DDR, PORTPIN_THREE);								// Set Port C bit 3 (CTS) for input
 		RESETREG(PC_ALT1, PORTPIN_THREE);
 		RESETREG(PC_ALT2, PORTPIN_THREE);


### PR DESCRIPTION
sets up UART0 to do both RTS and CTS

`wait_ESP32` now does a pure wait, with no timeout, as an Agon can’t operate without a working VDP, and the VDP hasn’t supported the lower baud rate in forever.
on successful receipt of a “general poll” response it now sends a "set feature flag" command to switch the VDP to use full duplex comms

from experimentation it seems that MOS doesn’t actually really need to care whether the VDP _actually_ switches over to full-duplex mode or not - it will carry on working regardless, therefore no checking is done to verify the switch has happened

includes a fix to `UART1_serial_GETCH` which was looking at the incorrect flag bit to determine if UART1 was connected - it was looking at the bit for UART0 so would always find a connection

based on a PR to Quark by S0urceror (breakintoprogram/agon-mos#126), but with a few additional changes