### PR TITLE
update boot file checking

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -68,6 +68,7 @@ typedef enum {
 #define VDP_mode				0x86
 #define VDP_rtc					0x87
 #define VDP_keystate			0x88
+#define VDP_checkkey			0x99
 #define VDP_palette				0x94
 #define VDP_logicalcoords		0xC0
 #define VDP_feature				0xF8


### PR DESCRIPTION
boot sequence will now try to run `!Boot.obey`, followed by `autoexec.obey` and finally attempt to exec `autoexec.txt`

NB it is only the first one of these found that will be run.

additionally if being run with a VDP that supports the “check key” command, it will omit running the boot file if the shift key is held down

fixes #57 and #102 