### PR TITLE
fixes for hotkey handling

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -771,11 +771,13 @@ int mos_cmdHOTKEY(char *ptr) {
 		for (key = 1; key <= 12; key++) {
 			hotkeyVar = NULL;
 			sprintf(label, "Hotkey$%d", key);
+			printf("F%d: %s", key, key < 10 ? " " : "");
 			if (getSystemVariable(label, &hotkeyVar) == 0) {
-				printf("F%d: %s%s\r\n", key, key < 10 ? " " : "", hotkeyVar->value);
+				printEscapedString(hotkeyVar->value);
 			} else {
-				printf("F%d: %sN/A\r\n", key, key < 10 ? " " : "");
+				printf("N/A");
 			}
+			printf("\r\n");
 		}
 		printf("\r\n");
 		return FR_OK;
@@ -800,11 +802,20 @@ int mos_cmdHOTKEY(char *ptr) {
 	}
 
 	// Remove surrounding quotes
-	// TODO consider whether this should be part of expandMacro?
+	// TODO consider whether this should be an optional part of expandMacro?
 	if (ptr[0] == '\"' && ptr[strlen(ptr) - 1] == '\"') {
 		ptr[strlen(ptr) - 1] = '\0';
 		ptr++;
 	}
+	// We need to add a `|M` to the end of the string...
+	// For now we'll use a crude length check on our ptr (args)
+	// ptr is at an unknown offset into our command buffer, but `*hotkey 12 ` is 10 characters
+	// This is imperfect and may fail in some edge-cases
+	// TODO This can more safely be done as part of expandMacro
+	if (strlen(ptr) > 242) {
+		return MOS_BAD_STRING;
+	}
+	strcat(ptr, "|M");
 
 	hotkeyString = expandMacro(ptr);
 	if (!hotkeyString) return FR_INT_ERR;


### PR DESCRIPTION
hotkey (function key) handling in the line editor will now skip any control characters it finds in the hotkey string.  it will also only insert up to the first CR character it finds, or the end of the string, whichever is first

the line editor will also now only auto-return on hotkey presses if the hotkey system variable ends with a CR character

the `*hotkey` command has been adjusted to automatically add a CR to the end of the hotkey definition to maintain existing behaviour.  hotkey values printed by this command are now also run thru `printEscapedString`

this means that if you wish to define a hotkey that will _not_ automatically have "return" pressed you can do so by defining a `Hotkey$n` system variable for that key that does not include a `|m` (CR) character.

Hotkey definitions can still potentially contain any characters - control characters will just be ignored.  the string can _potentially_ contain multiple lines but currently anything beyond the first will be ignored.  potential support for multi-line hotkey definitions is discussed in #114 

Finally the hotkey argument substitution in the line editor also no longer appends "rest" arguments to the end of the resultant string, restoring its behaviour to be more like MOS 2

fixes #132 and #131 