### PR TITLE
Auto-complete enhancements

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -924,7 +924,7 @@ int mos_cmdIFTHERE(char * ptr) {
 		result = FR_INVALID_PARAMETER;
 	} else {
 		// check if the file exists
-		result = resolvePath(filepath, NULL, &pathLength, NULL, NULL);
+		result = resolvePath(filepath, NULL, &pathLength, NULL, NULL, 0);
 	}
 	umm_free(filepath);
 
@@ -1108,7 +1108,10 @@ int mos_cmdDEL(char * ptr) {
 	BYTE	index = 0;
 
 	fr = extractString(ptr, &ptr, NULL, &filename, EXTRACT_FLAG_AUTO_TERMINATE);
-
+	
+	// TODO consider supporting more flags to control the behaviour of DEL
+	// For example we could change default behaviour to _not_ work with system/hidden files
+	// and have flags to permit them to be deleted
 	if (fr == FR_OK && (strcasecmp(filename, "-f") == 0)) {
 		force = TRUE;
 		fr = extractString(ptr, &ptr, NULL, &filename, EXTRACT_FLAG_AUTO_TERMINATE);
@@ -1125,7 +1128,7 @@ int mos_cmdDEL(char * ptr) {
 	}
 
 	// Work out our maximum path length
-	fr = resolvePath(filename, NULL, &maxLength, NULL, NULL);
+	fr = resolvePath(filename, NULL, &maxLength, NULL, NULL, 0);
 	if (!(fr == FR_OK || fr == FR_NO_FILE)) {
 		return fr;
 	}
@@ -1137,7 +1140,7 @@ int mos_cmdDEL(char * ptr) {
 	*resolvedPath = '\0';
 
 	length = maxLength;
-	fr = resolvePath(filename, resolvedPath, &length, &index, &dir);
+	fr = resolvePath(filename, resolvedPath, &length, &index, &dir, 0);
 	unlinkResult = fr;
 
 	while (fr == FR_OK) {
@@ -1171,7 +1174,7 @@ int mos_cmdDEL(char * ptr) {
 		// On any unlink error, break out of the loop
 		if (unlinkResult != FR_OK) break;
 		length = maxLength;
-		fr = resolvePath(filename, resolvedPath, &length, &index, &dir);
+		fr = resolvePath(filename, resolvedPath, &length, &index, &dir, 0);
 	}
 
 	umm_free(resolvedPath);
@@ -2389,7 +2392,7 @@ UINT24 mos_REN(char *srcPath, char *dstPath, BOOL verbose) {
 		addSlash = dstPath[strlen(dstPath) - 1] != '/';
 	}
 
-	fr = resolvePath(srcPath, NULL, &maxLength, NULL, NULL);
+	fr = resolvePath(srcPath, NULL, &maxLength, NULL, NULL, 0);
 	if (fr != FR_OK) {
 		// source couldn't be resolved, so no file to move
 		umm_free(resolvedDestPath);
@@ -2402,7 +2405,7 @@ UINT24 mos_REN(char *srcPath, char *dstPath, BOOL verbose) {
 	}
 
 	length = maxLength;
-	fr = resolvePath(srcPath, fullSrcPath, &length, &index, &dir);
+	fr = resolvePath(srcPath, fullSrcPath, &length, &index, &dir, 0);
 	renResult = fr;
 
 	while (fr == FR_OK) {
@@ -2423,7 +2426,7 @@ UINT24 mos_REN(char *srcPath, char *dstPath, BOOL verbose) {
 		if (usePattern && targetIsDir) {
 			// get next matching source, if there is one
 			length = maxLength;
-			fr = resolvePath(srcPath, fullSrcPath, &length, &index, &dir);
+			fr = resolvePath(srcPath, fullSrcPath, &length, &index, &dir, 0);
 		} else {
 			break;
 		}
@@ -2502,7 +2505,7 @@ UINT24 mos_COPY(char *srcPath, char *dstPath, BOOL verbose) {
 		addSlash = dstPath[strlen(dstPath) - 1] != '/';
 	}
 
-	fr = resolvePath(srcPath, NULL, &maxLength, NULL, NULL);
+	fr = resolvePath(srcPath, NULL, &maxLength, NULL, NULL, 0);
 	if (fr != FR_OK) {
 		// we only support copying files - a resolved source path returning `no file` or `no path` is an error
 		umm_free(resolvedDestPath);
@@ -2515,7 +2518,7 @@ UINT24 mos_COPY(char *srcPath, char *dstPath, BOOL verbose) {
 	}
 
 	length = maxLength;
-	fr = resolvePath(srcPath, fullSrcPath, &length, &index, &dir);
+	fr = resolvePath(srcPath, fullSrcPath, &length, &index, &dir, 0);
 	copyResult = fr;
 
 	while (fr == FR_OK) {
@@ -2545,7 +2548,7 @@ UINT24 mos_COPY(char *srcPath, char *dstPath, BOOL verbose) {
 		if (usePattern && targetIsDir) {
 			// get next matching source, if there is one
 			length = maxLength;
-			fr = resolvePath(srcPath, fullSrcPath, &length, &index, &dir);
+			fr = resolvePath(srcPath, fullSrcPath, &length, &index, &dir, 0);
 		} else {
 			break;
 		}

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -545,7 +545,7 @@ mos_api_editline:	LD	A, MB		; Check if MBASE is 0
 ;
 			CALL	NZ, SET_AHL24	; If it is running in classic Z80 mode, set U to MB
 ;
-			PUSH	DE		; UINT8	  flags
+			PUSH	DE		; UINT16  flags
 			PUSH	BC		; int 	  bufferLength
 			PUSH	HL		; char	* buffer
 			CALL	_mos_EDITLINE

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -569,7 +569,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags) {
 									}
 
 									if (!matched) {
-										// Find command in runpath, or given path
+										// Find command in runpath, or given path - omitting hidden/system files
 										// TODO think more on this `:` detection once we support runtypes
 										if (memchr(termStart, ':' , termLength) != NULL) {
 											sprintf(searchTerm, "%.*s*.bin", termLength, termStart);
@@ -577,7 +577,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags) {
 											sprintf(searchTerm, "run:%.*s*.bin", termLength, termStart);
 										}
 										resolveLength = bufferLength;
-										fr = resolvePath(searchTerm, path, &resolveLength, NULL, NULL);
+										fr = resolvePath(searchTerm, path, &resolveLength, NULL, NULL, AM_HID | AM_SYS);
 										if (fr == FR_OK) {
 											char * sourceLeaf = getFilepathLeafname(searchTerm);
 											int sourceOffset = sourceLeaf - searchTerm;
@@ -600,12 +600,10 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags) {
 									break;
 								}
 
-								// TODO fix this - filename completion currently can return hidden files - ideally it shouldn't
-								// This may mean adding a flags option to resolvePath, allowing a flag to ignore hidden files
-								// Which may mean adding another register to the resolvepath API for flags
 								sprintf(searchTerm, "%.*s*", termLength, termStart);
 								resolveLength = bufferLength;
-								fr = resolvePath(searchTerm, path, &resolveLength, NULL, NULL);
+								// Find file, omitting hidden/system files
+								fr = resolvePath(searchTerm, path, &resolveLength, NULL, NULL, AM_HID | AM_SYS);
 								if (fr == FR_OK) {
 									char * sourceLeaf = getFilepathLeafname(searchTerm);
 									int sourceOffset = sourceLeaf - searchTerm;

--- a/src/mos_editor.h
+++ b/src/mos_editor.h
@@ -15,7 +15,7 @@
 #define cmd_historyWidth	255
 #define cmd_historyDepth	16
 
-UINT24	mos_EDITLINE(char * buffer, int bufferLength, UINT8 clear);
+UINT24	mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags);
 void getModeInformation();
 void readPalette(BYTE entry, BOOL wait);
 

--- a/src/mos_file.h
+++ b/src/mos_file.h
@@ -10,7 +10,7 @@ BOOL isDirectory(char *path);
 char * getFilepathPrefixEnd(char * filepath);
 char * getFilepathLeafname(char * filepath);
 int getDirectoryForPath(char * srcPath, char * dir, int * length, BYTE index);
-int resolvePath(char * filepath, char * resolvedPath, int * length, BYTE * index, DIR * dir);
+int resolvePath(char * filepath, char * resolvedPath, int * length, BYTE * index, DIR * dir, BYTE flags);
 int resolveRelativePath(char * path, char * resolved, int length);
 bool isMoslet(char * filepath);
 int getResolvedPath(char * source, char ** resolvedPath);


### PR DESCRIPTION
Enhancements to tab-completion, improving behaviour and fixing issues.

Cursor position on an auto-complete is now at the end of the inserted item, rather than at the end of the buffer.  This is more expected behaviour.

A tab-complete that matches a filename that includes a space will cause the filename to be wrapped in double-quotes, which fixes an issue with tab-completion of such filenames

Tab-complete for a term that begins with a double-quote will close the double-quotes if a match is found, whether or not the completed term includes a space.  the leading double-quote should be ignored when searching for matches

Tab-complete now omits/ignores hidden and system files, as those are not, by default, visible in directory listings

The `mos_resolvePath` API now accepts a flags byte in the B register.  This is used to filter results based on file attributes on matches.  The lower 6 flag bits correspond to file attributes.  If the top-most flag bit is set, then resolve path will only find matches that include all of the attributes set (attributes _not_ set will be ignored).  When the top-most flag bit is clear resolve path will filter out any matches that one or more corresponding attributes set.  Setting the flag to zero ensures all potential matches are returned.

Fixes #95 