### PR TITLE
Add support for multi-line aliases

### DIFF
--- a/main.c
+++ b/main.c
@@ -243,7 +243,7 @@ int main(void) {
 	//
 	while (1) {
 		if (mos_input(&cmd, sizeof(cmd)) == 13) {
-			int err = mos_exec(&cmd, TRUE, 0);
+			int err = mos_exec(&cmd, true);
 			createOrUpdateSystemVariable("Sys$ReturnCode", MOS_VAR_NUMBER, (void *)err);
 			if (err > 0) {
 				mos_error(err);

--- a/src/mos.h
+++ b/src/mos.h
@@ -62,7 +62,8 @@ char *	mos_trim(char * s, bool removeLeadingAsterisks, bool removeTrailingSpaces
 int		mos_runBin(UINT24 addr, char * args);
 int		mos_runBinFile(char * filepath, char * args);
 int		mos_runOrLoadFile(char * args, bool run);
-int		mos_exec(char * buffer, BOOL in_mos, BYTE depth);
+int		mos_execAlias(char * token, char * args, char * saveToken, BOOL in_mos);
+int		mos_exec(char * buffer, BOOL in_mos);
 UINT8 	mos_execMode(UINT8 * ptr);
 
 int		mos_mount(void);


### PR DESCRIPTION
Aliases, whether they are direct command aliases or load/run types, are now all handled in the same way, using a new `mos_execAlias` function.

This function will support multi-line aliases.

Command depth detection, which was used to detect infinite loops in command aliases, has been moved to use a global variable for the depth instead of an argument on the `mos_exec` function.  This means it can now also detect infinite loops in file load/run type aliases as well as command aliases, and also with the use of the `exec <scriptfile>` and `obey <obeyfile>` commands.  The maximum depth remains at 10.