### PR TITLE
add support for variable expansion to resolvepath

### DIFF
--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -577,7 +577,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags) {
 											sprintf(searchTerm, "run:%.*s*.bin", termLength, termStart);
 										}
 										resolveLength = bufferLength;
-										fr = resolvePath(searchTerm, path, &resolveLength, NULL, NULL, AM_HID | AM_SYS);
+										fr = resolvePath(searchTerm, path, &resolveLength, NULL, NULL, AM_HID | AM_SYS | RESOLVE_OMIT_EXPAND);
 										if (fr == FR_OK) {
 											char * sourceLeaf = getFilepathLeafname(searchTerm);
 											int sourceOffset = sourceLeaf - searchTerm;
@@ -603,7 +603,7 @@ UINT24 mos_EDITLINE(char * buffer, int bufferLength, UINT16 flags) {
 								sprintf(searchTerm, "%.*s*", termLength, termStart);
 								resolveLength = bufferLength;
 								// Find file, omitting hidden/system files
-								fr = resolvePath(searchTerm, path, &resolveLength, NULL, NULL, AM_HID | AM_SYS);
+								fr = resolvePath(searchTerm, path, &resolveLength, NULL, NULL, AM_HID | AM_SYS | RESOLVE_OMIT_EXPAND);
 								if (fr == FR_OK) {
 									char * sourceLeaf = getFilepathLeafname(searchTerm);
 									int sourceOffset = sourceLeaf - searchTerm;

--- a/src/mos_file.h
+++ b/src/mos_file.h
@@ -6,6 +6,9 @@
 
 extern TCHAR	cwd[256];
 
+#define RESOLVE_OMIT_EXPAND			0x40
+#define RESOLVE_MATCH_ALL_ATTRIBS	0x80
+
 BOOL isDirectory(char *path);
 char * getFilepathPrefixEnd(char * filepath);
 char * getFilepathLeafname(char * filepath);
@@ -13,7 +16,7 @@ int getDirectoryForPath(char * srcPath, char * dir, int * length, BYTE index);
 int resolvePath(char * filepath, char * resolvedPath, int * length, BYTE * index, DIR * dir, BYTE flags);
 int resolveRelativePath(char * path, char * resolved, int length);
 bool isMoslet(char * filepath);
-int getResolvedPath(char * source, char ** resolvedPath);
+int getResolvedPath(char * source, char ** resolvedPath, BYTE flags);
 int copyFile(char * source, char * dest);
 
 #endif MOS_FILE_H

--- a/src/mos_sysvars.c
+++ b/src/mos_sysvars.c
@@ -1024,19 +1024,6 @@ char * expandVariableToken(char * token) {
 	return expandVariable(var, false);
 }
 
-int expandPath(char * source, char ** resolvedPath) {
-	// Expand path, and resolve it
-	int result = FR_INT_ERR;
-	char * path = NULL;
-	char * expanded = expandMacro(source);
-	if (expanded == NULL) {
-		return result;
-	}
-	result = getResolvedPath(expanded, resolvedPath);
-	umm_free(expanded);
-	return result;
-}
-
 // For this to work as an API, it will need to change
 // it should return a status result value, and accept in parameters to allow this routine to return
 // both a pointer to a buffer for the result value, and a pointer to an integer for the the type of the result

--- a/src/mos_sysvars.h
+++ b/src/mos_sysvars.h
@@ -105,8 +105,6 @@ char *	expandVariable(t_mosSystemVariable * var, bool showWriteOnly);
 
 char *	expandVariableToken(char * token);
 
-int		expandPath(char * source, char ** resolvedPath);
-
 t_mosEvalResult * evaluateExpression(char * source);
 
 char *  getArgument(char * source, int argNo, char ** end);


### PR DESCRIPTION
the `resolvePath` function will now automatically perform variable expansion.  this behaviour can be prevented by setting a flag.  this means that the `mos_resolvepath` API will now by default perform variable expansion

the `getResolvedPath` function now accepts a `flags` byte which it passes thru to `resolvePath`.  this change allows us to remove the `expandPath`function

the `ifthere` command should now understand file paths that are wrapped in double-quotes

closes #146 