### PR TITLE
add two VDP protocol APIs

### DIFF
--- a/src/clock.c
+++ b/src/clock.c
@@ -21,6 +21,7 @@
 #include "defines.h"
 #include "uart.h"
 #include "clock.h"
+#include "mos.h"
 #include "strings.h"
 
 extern volatile BYTE vpd_protocol_flags;		// In globals.asm
@@ -64,7 +65,7 @@ void rtc_update() {
 	putch(VDP_rtc);
 	putch(0);					// 0: Get time
 
-	while ((vpd_protocol_flags & 0x20) == 0);	
+	wait_VDP(0x20);				// Wait for bit to be set, or timeout
 }
 
 // Unpack a 6-byte RTC packet into time struct

--- a/src/mos.c
+++ b/src/mos.c
@@ -69,8 +69,8 @@ extern int 		exec24(UINT24 addr, char * params);	// In misc.asm
 
 extern BYTE scrcols, scrcolours, scrpixelIndex; // In globals.asm
 extern volatile	BYTE keyascii;					// In globals.asm
-extern volatile	BYTE vpd_protocol_flags;		// In globals.asm
 extern BYTE 	rtc;							// In globals.asm
+extern volatile BYTE vpd_protocol_flags;		// In globals.asm
 
 static FATFS	fs;					// Handle for the file system
 
@@ -2948,6 +2948,23 @@ int mos_mount(void) {
 		strcpy(cwd, "No SD card present");
 	}
 	return ret;
+}
+
+// Wait for the VDP packet to come in, with a timeout
+// Parameters:
+// - mask: Mask for the protocol bits to match (packet types)
+// Returns:
+// - status code (FR_OK or FR_TIMEOUT)
+//
+UINT8 wait_VDP(UINT8 mask) {
+	int i;
+
+	for (i = 0; i < 250000; i++) {				// A small delay loop (~1s)
+		if ((vpd_protocol_flags & mask) == mask) {
+			return FR_OK;
+		}
+	}
+	return FR_TIMEOUT;
 }
 
 // Support functions for code-type system variables

--- a/src/mos.h
+++ b/src/mos.h
@@ -152,6 +152,8 @@ extern BOOL	sdcardDelay;
 
 UINT8	fat_EOF(FIL * fp);
 
+UINT8	wait_VDP(UINT8 mask);
+
 
 #define MOS_DIR_LONG_LISTING		1
 #define MOS_DIR_SHOW_HIDDEN			2

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -70,6 +70,7 @@
 			XREF	_mos_I2C_READ
 
 			XREF	_fat_EOF		; In mos.c
+			XREF	_wait_VDP
 
 			XREF	_open_UART1		; In uart.c
 			XREF	_close_UART1
@@ -197,8 +198,8 @@ mos_api_block1_start:	DW	mos_api_getkey		; 0x00
 			DW	mos_api_not_implemented	; 0x3e
 			DW	mos_api_not_implemented	; 0x3f
 
-			DW	mos_api_not_implemented	; 0x40
-			DW	mos_api_not_implemented	; 0x41
+			DW	mos_api_clear_vdp_flags	; 0x40
+			DW	mos_api_wait_vdp_flags	; 0x41
 			DW	mos_api_not_implemented	; 0x42
 			DW	mos_api_not_implemented	; 0x43
 			DW	mos_api_not_implemented	; 0x44
@@ -1577,6 +1578,29 @@ $$:			PUSH	DE		; int length
 			POP	HL
 			POP	IX
 			POP	DE
+			RET
+
+; Clear VDP flag(s)
+; C: bitmask of flags to clear
+; Returns:
+; - A: vdp flags
+mos_api_clear_vdp_flags:
+			PUSH	HL		; Save HL
+			LD	HL, _vpd_protocol_flags
+			LD	A, C
+			CPL			; Invert the bitmask
+			AND	(HL)		; Clear the requested flags
+			LD	(HL), A		; Save the new flags
+			POP	HL
+			RET
+
+; Wait until VDP flag(s) are set, or timeout
+; C: bitmask of flags to wait for
+; Returns:
+; - A = status code (0 = OK, 15 = timeout (FR_TIMEOUT))
+mos_api_wait_vdp_flags:
+			PUSH	BC
+			CALL	_wait_VDP
 			RET
 
 ; Open a file

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -1601,6 +1601,7 @@ mos_api_clear_vdp_flags:
 mos_api_wait_vdp_flags:
 			PUSH	BC
 			CALL	_wait_VDP
+			POP	BC
 			RET
 
 ; Open a file

--- a/src/mos_api.inc
+++ b/src/mos_api.inc
@@ -106,6 +106,11 @@ mos_getleafname:	EQU	3Ah
 mos_isdirectory:	EQU	3Bh
 mos_getabsolutepath:	EQU	3Ch
 
+; VDP Protocol apis
+;
+mos_clearvdpflags:	EQU	40h
+mos_waitforvdpflags:	EQU	41h
+
 ; FatFS file access functions
 ;
 ffs_fopen:		EQU	80h

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -113,8 +113,6 @@ BOOL insertCharacter(char *buffer, char c, int insertPos, int len, int limit) {
 // Insert into buffer a sub-string from `source` at `sourceOffset` of length `sourceLen` at `insertPos`
 // This will detect spaces in the source string and wrap the inserted string in double-quotes
 int insertString(char * buffer, char * source, int sourceLen, int sourceOffset, int insertPos, int len, int limit, char addedChar) {
-	// TODO this needs to detect if we are inserting with a leading double-quote already present
-	// and if so not insert another one, and ensure we add a closing double-quote at the end
 	int i;
 	int copyOffset;
 	int remainder = len - insertPos;

--- a/src/mos_sysvars.h
+++ b/src/mos_sysvars.h
@@ -8,7 +8,6 @@
 #include "ff.h"
 #include "umm_malloc.h"
 
-// TODO renumber these flags and split between number and string
 #define EXTRACT_FLAG_DECIMAL_ONLY	(1 << 0)
 #define EXTRACT_FLAG_POSITIVE_ONLY	(1 << 1)
 #define EXTRACT_FLAG_H_SUFFIX_HEX	(1 << 2)

--- a/src/timer.c
+++ b/src/timer.c
@@ -70,22 +70,3 @@ unsigned short get_timer0() {
 	unsigned char h = TMR0_DR_H;
 	return (h << 8) | l;
 }
-
-// Wait for the VDP packet to come in, with a timeout
-// Parameters:
-// - mask: Mask for the packet(s) we're expecting
-// Returns:
-// - True if the packet is received, False if there is a timeout
-//
-BOOL wait_VDP(unsigned char mask) {
-	int		i;
-	BOOL	retVal = 0;
-
-	for(i = 0; i < 250000; i++) {				// A small delay loop (~1s)
-		if(vpd_protocol_flags & mask) {			// If we get a result then
-			retVal = 1;							// Set the return value to true
-			break;								// And exit the loop
-		}
-	}
-	return retVal;
-}

--- a/src/timer.h
+++ b/src/timer.h
@@ -20,7 +20,6 @@ extern volatile BYTE vpd_protocol_flags;		// In globals.asm
 unsigned short  init_timer0(int interval, int clkdiv, unsigned char ctrlbits);
 void            enable_timer0(unsigned char enable);
 unsigned short  get_timer0();
-BOOL 			wait_VDP(unsigned char mask);
 
 void            wait_timer0();  // In misc.asm
 


### PR DESCRIPTION
mos_clearvdpflags (0x40) accepts a bitmask value of flags in the C register, clears those bits from the VDP protocol flags byte, and returns back the updated flags byte in the A register

mos_waitforvdpflags (0x41) accepts a bitmask value of flags in the C register, and will wait for those flags to all be set, or times out after roughly 1s.  it will return FR_OK or FR_TIMEOUT
