### PR TITLE
Add missing fatfs API calls

### DIFF
--- a/src/misc.asm
+++ b/src/misc.asm
@@ -24,6 +24,7 @@
 			XDEF	SWITCH_A
 			XDEF	SET_AHL24
 			XDEF	GET_AHL24
+			XDEF	FIX_HLU24
 			XDEF	SET_ADE24
 			XDEF	SET_ABC24
 			XDEF	SET_AIX24
@@ -69,6 +70,18 @@ GET_AHL24:		PUSH	HL
 			LD	A, (HL)
 			POP	HL
 			RET
+
+; Optionally set MSB of HL(U) to MB, if needed
+; Sets U of HLU to MB if MB != 0 and U is not already set
+;
+FIX_HLU24:		LD	A, MB
+			OR	A
+			RET	Z
+			CALL	GET_AHL24
+			OR 	A, A
+			RET	Z
+			LD	A, MB
+			JP	SET_AHL24
 
 ; Set the MSB of DE (U) to A
 ;

--- a/src/mos.c
+++ b/src/mos.c
@@ -2944,6 +2944,28 @@ UINT8 fat_EOF(FIL * fp) {
 	return 0;
 }
 
+UINT32 fat_size(FIL * fp) {
+	return f_size(fp);
+}
+
+UINT8 fat_error(FIL * fp) {
+	return f_error(fp);
+}
+
+int fat_getfree(const TCHAR * path, DWORD * clusters, DWORD * clusterSize) {
+	FATFS * fs = NULL;
+	int result;
+	if (clusters == NULL || clusterSize == NULL) {
+		return FR_INVALID_PARAMETER;
+	}
+	if (path == NULL) {
+		path = "";		// Default path for our mounted drive
+	}
+	result = f_getfree(path, clusters, &fs);
+	*clusterSize = result == FR_OK ? fs->csize : 0;
+	return result;
+}
+
 // (Re-)mount the MicroSD card
 // Parameters:
 // - None

--- a/src/mos.c
+++ b/src/mos.c
@@ -2931,6 +2931,10 @@ UINT24	mos_GETFIL(UINT8 fh) {
 	return 0;
 }
 
+UINT32 fat_tell(FIL * fp) {
+	return f_tell(fp);
+}
+
 // Check whether file is at EOF (end of file)
 // Parameters:
 // - fp: Pointer to file structure

--- a/src/mos.h
+++ b/src/mos.h
@@ -151,6 +151,9 @@ extern TCHAR	cwd[256];
 extern BOOL	sdcardDelay;
 
 UINT8	fat_EOF(FIL * fp);
+UINT32	fat_size(FIL * fp);
+UINT8	fat_error(FIL * fp);
+int		fat_getfree(const TCHAR * path, DWORD * clusters, DWORD * clusterSize);
 
 UINT8	wait_VDP(UINT8 mask);
 

--- a/src/mos.h
+++ b/src/mos.h
@@ -150,6 +150,7 @@ UINT24	mos_GETFIL(UINT8 fh);
 extern TCHAR	cwd[256];
 extern BOOL	sdcardDelay;
 
+UINT32	fat_tell(FIL * fp);
 UINT8	fat_EOF(FIL * fp);
 UINT32	fat_size(FIL * fp);
 UINT8	fat_error(FIL * fp);


### PR DESCRIPTION
Work in progress...

adds a new utility call `FIX_HLU24` - other fatfs APIs will check MB for zero, and if it is then read the U byte from HLU and if it is clear sets to MB.  as this is common code this new utility call does that whole process in one step

this is used in the new ffs_api_fsync implementation

its use should be rolled out to other ffs_api_* calls that optionally set U of HLU to MB in this manner to save some bytes/complexity