### PR TITLE
fix `run` command to be MOS 2 compatible

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -1235,14 +1235,23 @@ int mos_cmdLOADFILE(char *ptr) {
 // - MOS error code
 //
 int mos_cmdRUN(char *ptr) {
-	UINT24	addr;
+	UINT24	addr = 0;
 	int		result;
-
-	if (!extractNumber(ptr, &ptr, NULL, (int *)&addr, 0)) {
+	
+	// First argument should be a number, and if not should be absent, or a `.` for "default address"
+	if (!extractNumber(ptr, &ptr, NULL, (int *)&addr, 0) &&
+		(*ptr == '\0' || (*ptr =='.' && (ptr[1] == '\0' || ptr[1] == ' ')))
+	) {
 		addr = MOS_defaultLoadAddress;
+		if (*ptr == '.') {
+			ptr++;
+		}
 	}
 	// For compatibility we will trim trailing spaces from arguments
 	ptr = mos_trim(ptr, false, true);
+	if (addr == 0) {
+		return FR_INVALID_PARAMETER;
+	}
 	result = mos_runBin(addr, ptr);
 	return result;
 }


### PR DESCRIPTION
changes to how the `run` command in MOS 3 interprets its arguments introduced a bug that made it incompatible with commands written for MOS 1 and 2

the command `run . <filename>` should run the currently loaded program at the default address, passing in `<filename>` as the argument string.  instead the parser was seeing that `.` is not a number, and then passing the whole argument string

a side-effect of this is that `run <filename>` would work - but that behaviour is not desired, as ideally in the future that _should_ be equivalent to `runfile <filename>`

this update ensures that `run` now properly checks its arguments.  you must now either use no arguments, or provide a numeric address or a dot.

if the first argument is present but non-numeric an error will be reported - this differs from MOS 1 and 2, but is more correct behaviour, and is essentially compliant with existing documented examples