### PR TITLE
speed boosts

### DIFF
--- a/src/serial.asm
+++ b/src/serial.asm
@@ -95,7 +95,7 @@ UART0_serial_TX:	PUSH		BC			; Stack BC
 			PUSH		AF 			; Stack AF
 			LD		BC,TX_WAIT		; Set CB to the transmit timeout
 UART0_serial_TX1:	IN0		A,(UART0_REG_LSR)	; Get the line status register
-			AND 		UART_LSR_ETX		; Check for TX empty
+			AND 		UART_LSR_ETH		; Check for TX hold register empty
 			JR		NZ, UART0_serial_TX2	; If set, then TX is empty, goto transmit
 			DEC		BC
 			LD		A, B
@@ -122,7 +122,7 @@ UART1_serial_TX:	PUSH		BC			; Stack BC
 			PUSH		AF 			; Stack AF
 			LD		BC,TX_WAIT		; Set CB to the transmit timeout
 UART1_serial_TX1:	IN0		A,(UART1_REG_LSR)	; Get the line status register
-			AND 		UART_LSR_ETX		; Check for TX empty
+			AND 		UART_LSR_ETH		; Check for TX hold register empty
 			JR		NZ, UART1_serial_TX2	; If set, then TX is empty, goto transmit
 			DEC		BC
 			LD		A, B

--- a/src_startup/init_params_f92.asm
+++ b/src_startup/init_params_f92.asm
@@ -140,7 +140,10 @@ __init:			ld a, %FF
 ;
 			ld a, __FLASH_ADDR_U_INIT_PARAM
 			out0 (FLASH_ADDR_U), a
-			ld a, __FLASH_CTL_INIT_PARAM
+			; Change the flash control register to zero wait states
+			; NB using a constant here as I couldn't work out how __FLASH_CTL_INIT_PARAM is set
+			; ld a, __FLASH_CTL_INIT_PARAM
+			ld a, 08h
 			out0 (FLASH_CTRL), a
 
 			ld a, __RAM_ADDR_U_INIT_PARAM


### PR DESCRIPTION
in `serial.asm` this changes a check inside the two `*_serial_TX` routines to check against the “TX hold register”.  this allows transmits to happen as soon as the serial system is no longer saying “hold”.  in benchmark testing this is is providing a very significant boost to our comms speed from MOS to the VDP, from around 640KBit/sec to 877KBit/sec.  as this is a measure of data bits sent, and our comms config sents 1 stop-bit per byte, this is getting very close to the maximum theoretical data rate

also changes the `FLASH_CTRL` configuration to use a value of `0x08`, which sets ROM/flash memory access to zero wait-states..  this boosts the perfomance of calling MOS APIs by around 17% (I could not see how to adjust the `__FLASH_CTL_INIT_PARAM` setting - this does not appear to be a configuration directly exposed inside ZDS, and is not set in the source.  for simplicity a constant is being used in the source)

these changes were copied from a commit by @tomm on his experimental MOS 2.4 agondev port (#156)