### PR TITLE
Updates to MOS 3 APIs for 32-bit values

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -2960,8 +2960,12 @@ UINT24	mos_GETFIL(UINT8 fh) {
 	return 0;
 }
 
-UINT32 fat_tell(FIL * fp) {
-	return f_tell(fp);
+UINT8 fat_tell(FIL * fp, DWORD * offset) {
+	if (fp == NULL || offset == NULL) {
+		return FR_INVALID_PARAMETER;
+	}
+	*offset = f_tell(fp);
+	return FR_OK;
 }
 
 // Check whether file is at EOF (end of file)
@@ -2977,8 +2981,12 @@ UINT8 fat_EOF(FIL * fp) {
 	return 0;
 }
 
-UINT32 fat_size(FIL * fp) {
-	return f_size(fp);
+UINT8 fat_size(FIL * fp, DWORD * size) {
+	if (fp == NULL || size == NULL) {
+		return FR_INVALID_PARAMETER;
+	}
+	*size = f_size(fp);
+	return FR_OK;
 }
 
 UINT8 fat_error(FIL * fp) {

--- a/src/mos.h
+++ b/src/mos.h
@@ -150,9 +150,9 @@ UINT24	mos_GETFIL(UINT8 fh);
 extern TCHAR	cwd[256];
 extern BOOL	sdcardDelay;
 
-UINT32	fat_tell(FIL * fp);
+UINT8	fat_tell(FIL * fp, DWORD * offset);
 UINT8	fat_EOF(FIL * fp);
-UINT32	fat_size(FIL * fp);
+UINT8	fat_size(FIL * fp, DWORD * size);
 UINT8	fat_error(FIL * fp);
 int		fat_getfree(const TCHAR * path, DWORD * clusters, DWORD * clusterSize);
 


### PR DESCRIPTION
For consistency it has been decided that APIs that require or return 32-bit arguments should use a pointer to a number stored in memory.

The original implementations for `ffs_fsize` and `ffs_ftell` in the alpha and beta releases of MOS 3 returned their 32-bit value spread across 2 registers, specifically `DE(U)` and `C`.  This was, essentially, following the lead of the two `*_flseek` APIs, introduced in MOS 1.03, which accept a 32-bit value spread across two registers, with 24-bits in one register, and 8 bits in the other.  The underlying FatFS functions for these two APIs just return a 32-bit number, so this was the simplest approach.

However this approach however is not friendly to Z80 code, as it uses the upper byte in the `DE`.

In contrast, the `ffs_getfree` and `ffs_getlabel` commands accepted a pointer to use to return the 32-bit values they will return, essentially because the underlying FatFS functions for these two calls work this way as their primary return value is an `FRESULT`.

Using a pointer to a 32-bit value inherently is compatible with both Z80 code and ADL-mode (eZ80) code.  On reflection it is therefore a sensible convention to use and follow for all of our MOS APIs.  As MOS 3 has not had an official release and is still in beta we have the opportunity adopt this convention for new APIs we have added.

This PR therefore changes the new `ffs_fsize` and `ffs_ftell` APIs to follow this convention.

This PR will also add new variants of the two `*_flseek` APIs that follow this convention.