### PR TITLE
add APIs for low-level SD card access

### DIFF
--- a/src/mos_api.inc
+++ b/src/mos_api.inc
@@ -112,6 +112,12 @@ mos_getabsolutepath:	EQU	3Ch
 mos_clearvdpflags:	EQU	40h
 mos_waitforvdpflags:	EQU	41h
 
+; Low-level SD card functions
+;
+sd_init:		EQU	70h
+sd_readblocks:	EQU	71h
+sd_writeblocks:	EQU	72h
+
 ; FatFS file access functions
 ;
 ffs_fopen:		EQU	80h

--- a/src/mos_api.inc
+++ b/src/mos_api.inc
@@ -114,9 +114,10 @@ mos_waitforvdpflags:	EQU	41h
 
 ; Low-level SD card functions
 ;
-sd_init:		EQU	70h
-sd_readblocks:	EQU	71h
-sd_writeblocks:	EQU	72h
+sd_getunlockcode:	EQU	70h
+sd_init:		EQU	71h
+sd_readblocks:		EQU	72h
+sd_writeblocks:		EQU	73h
 
 ; FatFS file access functions
 ;

--- a/src/sd.h
+++ b/src/sd.h
@@ -21,4 +21,12 @@ BYTE	SD_writeBlocks(DWORD addr, BYTE *buf, WORD count);
 
 BYTE	SD_init();
 
+BYTE	SD_readBlocks_API(DWORD * addr, BYTE *buf, WORD count) {
+	return SD_readBlocks(*addr, buf, count);
+}
+
+BYTE	SD_writeBlocks_API(DWORD * addr, BYTE *buf, WORD count) {
+	return SD_writeBlocks(*addr, buf, count);
+}
+
 #endif SD_H

--- a/src/sd.h
+++ b/src/sd.h
@@ -12,21 +12,65 @@
 #ifndef SD_H
 #define SD_H
 
-#define SD_SUCCESS  0
-#define SD_ERROR    1
+#include <stdlib.h>
+
+#define SD_SUCCESS	0
+#define SD_ERROR	1
+#define SD_LOCKED	2
 #define SD_READY	0
+
+extern int quickrand(void);
+
+int	unlockCode = 0;
 
 BYTE	SD_readBlocks(DWORD addr, BYTE *buf, WORD count);
 BYTE	SD_writeBlocks(DWORD addr, BYTE *buf, WORD count);
 
 BYTE	SD_init();
 
-BYTE	SD_readBlocks_API(DWORD * addr, BYTE *buf, WORD count) {
-	return SD_readBlocks(*addr, buf, count);
+void	SD_getUnlockCode(int * code) {
+	if (code == NULL) {
+		return;
+	}
+	while (unlockCode == 0) {
+		// Generate an unlock code
+		BYTE * codePtr = (BYTE *)&unlockCode;
+		codePtr[0] = ((BYTE)quickrand()) ^ 0xDE;
+		codePtr[1] = ((BYTE)quickrand()) ^ 0xAD;
+		codePtr[2] = ((BYTE)quickrand()) ^ 0x5D;
+		// unlockCode = rand() ^ 0xDEAD5D;
+	}
+	*code = unlockCode;
 }
 
-BYTE	SD_writeBlocks_API(DWORD * addr, BYTE *buf, WORD count) {
-	return SD_writeBlocks(*addr, buf, count);
+BYTE	SD_init_API(int * code) {
+	if ((code == NULL) || (*code != unlockCode)) {
+		return SD_LOCKED;
+	}
+	return SD_init();
+}
+
+BYTE	SD_readBlocks_API(void * addr, BYTE *buf, WORD count) {
+	// Check that value at addr+sizeof(DWORD) matches unlockCode
+	if (addr == NULL) {
+		return SD_ERROR;
+	}
+	if ((unlockCode == 0) || (*(int *)(addr + sizeof(DWORD)) != unlockCode)) {
+		return SD_LOCKED;
+	}
+	// Read the blocks from the SD card
+	return SD_readBlocks(*(DWORD *)addr, buf, count);
+}
+
+BYTE	SD_writeBlocks_API(void * addr, BYTE *buf, WORD count) {
+	// Check that value at addr+sizeof(DWORD) matches unlockCode
+	if (addr == NULL) {
+		return SD_ERROR;
+	}
+	if ((unlockCode == 0) || (*(int *)(addr + sizeof(DWORD)) != unlockCode)) {
+		return SD_LOCKED;
+	}
+	return SD_writeBlocks(*(DWORD *)addr, buf, count);
 }
 
 #endif SD_H


### PR DESCRIPTION
adds in four APIs, `sd_getunlockcode`, `sd_init`, `sd_readblocks` and `sd_writeblocks`

these provide low-level access to the SD card, and are simple wrappers over the underlying functions that FatFS uses for disk access (as used inside `diskio.c`)

to guard against accidental usage of these APIs, programs must use `sd_getunlockcode` and then provide that unlock code when calling `sd_init`, `sd_readblocks` and `sd_writeblocks`