### PR TITLE
add a mos_getfunction API (0x50)

### DIFF
--- a/src/mos.c
+++ b/src/mos.c
@@ -308,7 +308,7 @@ int mos_runBinFile(char * filepath, char * args) {
 		return MOS_OUT_OF_MEMORY;
 	}
 
-	result = resolveRelativePath(resolvedPath, fullyResolvedPath, pathLen);
+	result = resolveRelativePath(resolvedPath, fullyResolvedPath, &pathLen);
 	if (result == FR_OK) {
 		if (isMoslet(fullyResolvedPath)) {
 			addr = MOS_starLoadAddress;
@@ -392,7 +392,7 @@ int mos_execAlias(char * token, char * args, char * saveToken, BOOL in_mos) {
 		return MOS_NOT_IMPLEMENTED;
 	}
 
-	expandedAlias = substituteArguments(alias, args, false);
+	expandedAlias = substituteArguments(alias, args, 0);
 	if (!expandedAlias) {
 		umm_free(alias);
 		return FR_INT_ERR;
@@ -1043,7 +1043,10 @@ int mos_cmdOBEY(char *ptr) {
 		absoluteDirectory = umm_malloc(dirLength + strlen(cwd) + 1);
 		if (directory && absoluteDirectory) {
 			fr = getDirectoryForPath(expandedPath, directory, &dirLength, 0);
-			if (fr == FR_OK) fr = resolveRelativePath(directory, absoluteDirectory, dirLength + strlen(cwd) + 1);
+			if (fr == FR_OK) {
+				int pathLen = dirLength + strlen(cwd) + 1;
+				fr = resolveRelativePath(directory, absoluteDirectory, &pathLen);
+			}
 			if (fr == FR_OK) {
 				createOrUpdateSystemVariable("Obey$Dir", MOS_VAR_STRING, absoluteDirectory);
 			}
@@ -1060,7 +1063,7 @@ int mos_cmdOBEY(char *ptr) {
 		while (!f_eof(&fil)) {
 			line++;
 			f_gets(buffer, size, &fil);
-			substituted = substituteArguments(buffer, ptr, true);
+			substituted = substituteArguments(buffer, ptr, 1);
 			if (!substituted) {
 				fr = MOS_OUT_OF_MEMORY;
 				break;

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -2276,6 +2276,22 @@ $$:			PUSH	BC		; WORD count
 			POP	BC
 			RET
 
+; C calling convention functions
+
+; Get a pointer to a system variable
+; Returns:
+; HLU: Pointer to system variables (see mos_api.asm for more details)
+;
+func_getsysvars:	LD	HL, _sysvars
+			RET
+
+; Get the address of the keyboard map
+; Returns:
+; HLU: Base address of the keymap
+;
+func_getkbmap:		LD	HL, _keymap
+			RET
+
 ; Get function
 ; Only usable for code in ADL mode
 ; C: Flags (must be zero for now)
@@ -2335,6 +2351,7 @@ mos_function_block_start:
 			DW24	_resolvePath	; 0x0D
 			DW24	_getDirectoryForPath	; 0x0E
 			DW24	_resolveRelativePath	; 0x0F
-
+			DW24	func_getsysvars	; 0x10
+			DW24	func_getkbmap	; 0x11
 
 mos_function_block_size:	EQU 	($ - mos_function_block_start) / 3

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -2325,5 +2325,16 @@ mos_function_block_start:
 			DW24	0		; 0x03 (reserved for potential future _SD_status function)
 			DW24	0		; 0x04 (reserved for potential future _SD_ioctl function)
 			DW24	_f_printf	; 0x05
+			DW24	_f_findfirst	; 0x06
+			DW24	_f_findnext	; 0x07
+			DW24	_open_UART1	; 0x08
+			DW24	_setVarVal	; 0x09
+			DW24	_readVarVal	; 0x0A
+			DW24	_gsTrans	; 0x0B
+			DW24	_substituteArgs	; 0x0C
+			DW24	_resolvePath	; 0x0D
+			DW24	_getDirectoryForPath	; 0x0E
+			DW24	_resolveRelativePath	; 0x0F
+
 
 mos_function_block_size:	EQU 	($ - mos_function_block_start) / 3

--- a/src/mos_api.asm
+++ b/src/mos_api.asm
@@ -1430,7 +1430,7 @@ $$:			PUSH 	HL
 ; Returns:
 ; - BCU: Calculated length of destination string
 ;
-; int substituteArgs(char * template, char * args, char * dest, int length, bool omitRest)
+; int substituteArgs(char * template, char * args, char * dest, int length, BYTE flags)
 mos_api_substituteargs:
 			PUSH	BC		; BYTE flags (bool omitRest)
 			PUSH	DE		; UINT24 length
@@ -1602,7 +1602,7 @@ $$:			LD	A, 5		; Return 5 FR_NO_PATH
 ; Returns:
 ; - A: Status code
 ;
-; int resolveRelativePath(char * path, char * resolved, int length);
+; int resolveRelativePath(char * path, char * resolved, int * length);
 ; For now, we will not support returning back length, or calculating length
 mos_api_getabsolutepath:
 			LD	A, MB		; Check if MBASE is 0
@@ -1610,7 +1610,9 @@ mos_api_getabsolutepath:
 			JR	Z, $F		; If it is, we can assume pointers are 24 bit
 			CALL	SET_AHL24
 			CALL	SET_AIX24
-$$:			PUSH	DE		; int length
+$$:			LD	(_scratchpad), DE
+			LD	DE, _scratchpad
+			PUSH	DE		; int * length
 			PUSH	IX		; char * resolved
 			PUSH	HL		; char * path
 			CALL	_resolveRelativePath	; Call the C function resolveRelativePath
@@ -1618,6 +1620,7 @@ $$:			PUSH	DE		; int length
 			POP	HL
 			POP	IX
 			POP	DE
+			LD	DE, (_scratchpad)	; Return length in DEU
 			RET
 
 ; Clear VDP flag(s)

--- a/src/mos_api.inc
+++ b/src/mos_api.inc
@@ -112,6 +112,10 @@ mos_getabsolutepath:	EQU	3Ch
 mos_clearvdpflags:	EQU	40h
 mos_waitforvdpflags:	EQU	41h
 
+; Function and module APIs
+;
+mos_getfunction:	EQU	50h
+
 ; Low-level SD card functions
 ;
 sd_getunlockcode:	EQU	70h

--- a/src/mos_editor.c
+++ b/src/mos_editor.c
@@ -292,7 +292,7 @@ BYTE handleHotkey(UINT8 fkey, char * buffer, int bufferLength, int insertPos, in
 			return 0;
 		}
 
-		substitutedString = substituteArguments(hotkeyString, buffer, true);
+		substitutedString = substituteArguments(hotkeyString, buffer, 1);
 		umm_free(hotkeyString);
 		if (!substitutedString) {
 			return 0;

--- a/src/mos_file.c
+++ b/src/mos_file.c
@@ -366,8 +366,11 @@ int resolvePath(char * argpath, char * resolvedPath, int * length, BYTE * index,
 }
 
 // resolveRelativePath resolves a relative path to an absolute path
+// NB length is a pointer to allow this function to change in the future
+// to return a length when no `resolved` pointer is provided,
+// and thus provide similar functionality to other path functions/APIs
 //
-int resolveRelativePath(char * path, char * resolved, int length) {
+int resolveRelativePath(char * path, char * resolved, int * length) {
 	int result;
 	char * leafname;
 	char leafChar;
@@ -380,7 +383,7 @@ int resolveRelativePath(char * path, char * resolved, int length) {
 	leafChar = *leafname;
 	if (leafname == path) {
 		// only have a leafname, so just return cwd + leafname
-		if (length >= strlen(path) + strlen(cwd) + 1) {
+		if (*length >= strlen(path) + strlen(cwd) + 1) {
 			if (leafChar == '\0') {
 				sprintf(resolved, "%s", cwd);
 			} else {
@@ -395,12 +398,12 @@ int resolveRelativePath(char * path, char * resolved, int length) {
 
 	result = f_chdir(path);
 	if (result == FR_OK) {
-		result = f_getcwd(resolved, length);
+		result = f_getcwd(resolved, *length);
 	}
 	// append our leafname to resolved
 	*leafname = leafChar;
 	if (result == FR_OK) {
-		if (strlen(resolved) + strlen(leafname) + 1 > length) {
+		if (strlen(resolved) + strlen(leafname) + 1 > *length) {
 			return MOS_OUT_OF_MEMORY;
 		}
 		if (leafChar != '\0') {

--- a/src/mos_file.h
+++ b/src/mos_file.h
@@ -14,7 +14,7 @@ char * getFilepathPrefixEnd(char * filepath);
 char * getFilepathLeafname(char * filepath);
 int getDirectoryForPath(char * srcPath, char * dir, int * length, BYTE index);
 int resolvePath(char * filepath, char * resolvedPath, int * length, BYTE * index, DIR * dir, BYTE flags);
-int resolveRelativePath(char * path, char * resolved, int length);
+int resolveRelativePath(char * path, char * resolved, int * length);
 bool isMoslet(char * filepath);
 int getResolvedPath(char * source, char ** resolvedPath, BYTE flags);
 int copyFile(char * source, char * dest);

--- a/src/mos_sysvars.c
+++ b/src/mos_sysvars.c
@@ -1112,7 +1112,7 @@ char * getArgument(char * source, int argNo, char ** end) {
 // Returns:
 // - The length of the substituted string
 //
-int substituteArgs(char * template, char * args, char * dest, int length, bool omitRest) {
+int substituteArgs(char * template, char * args, char * dest, int length, BYTE flags) {
 	char * end = template + strlen(template);
 	char * argument;
 	int argNo;
@@ -1121,6 +1121,7 @@ int substituteArgs(char * template, char * args, char * dest, int length, bool o
 	int size = 0;
 	int destRemaining = length;
 	bool copying = (dest != NULL);
+	bool omitRest = (flags & 1);
 
 	while (template < end) {
 		if (*template == '%') {
@@ -1210,9 +1211,9 @@ int substituteArgs(char * template, char * args, char * dest, int length, bool o
 
 // wrapper call for substituteArgs to return a newly allocated string
 //
-char * substituteArguments(char * source, char * args, bool omitRest) {
+char * substituteArguments(char * source, char * args, BYTE flags) {
 	char * dest;
-	int size = substituteArgs(source, args, NULL, 0, omitRest);
+	int size = substituteArgs(source, args, NULL, 0, flags);
 	if (size == 0) {
 		return NULL;
 	}
@@ -1220,7 +1221,7 @@ char * substituteArguments(char * source, char * args, bool omitRest) {
 	if (dest == NULL) {
 		return NULL;
 	}
-	substituteArgs(source, args, dest, size, omitRest);
+	substituteArgs(source, args, dest, size, flags);
 	dest[size + 1] = '\0';		// is this needed??
 	return dest;
 }

--- a/src/mos_sysvars.h
+++ b/src/mos_sysvars.h
@@ -108,8 +108,8 @@ t_mosEvalResult * evaluateExpression(char * source);
 
 char *  getArgument(char * source, int argNo, char ** end);
 
-int substituteArgs(char * template, char * args, char * dest, int length, bool omitRest);
+int substituteArgs(char * template, char * args, char * dest, int length, BYTE flags);
 
-char *	substituteArguments(char * source, char * args, bool omitRest);
+char *	substituteArguments(char * source, char * args, BYTE flags);
 
 #endif MOS_SYSVARS_H

--- a/src/tests.c
+++ b/src/tests.c
@@ -12,6 +12,9 @@
 
 #if DEBUG > 0
 
+// TODO some of the functions tested here have had their arguments slightly changed
+// e.g. resolveRelativePath now takes a pointer for length
+
 #define MG_MAX_ITEMS	64
 #define MG_ITERS 1000
 struct mg_item_t {


### PR DESCRIPTION
this function returns a pointer to a function.  in general these should be functions that follow the C calling convention, and will be used to expose raw C functions

parameters are:
C = flags (must be zero for now)
B = function number

returns:
A = status (0, 19 or 20)
HL = pointer to function, or 0 if invalid

for now exposes the SD card C functions, and also `f_printf` which we can’t easily expose as a MOS-style API, as well as some other functions that use the IX register and so are awkward to call from C

flags are included for future use.  this may in the future allow a way to go beyond 256 functions, or if/when we introduce MOS modules control whether functions from modules will be returned or not

when called from Z80 mode, will return 20 (invalid command) as you can’t use these functions in Z80 mode.  (“invalid command” chosen over “not implemented” as the API _is_ implemented, it just can’t be used)

if the function number is out of range, or flags are not zero, returns 19 (invalid parameter)